### PR TITLE
Fix WebSocket 400 error.

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -5,23 +5,29 @@ error_log /tmp/log debug;
 # Required - just leave the defaults for now.
 events {}
 http {
-        # These host names are available in a docker-compose environment via
-        # docker linking.
-        upstream ui {
-                server ui:4400;
-        }
-        upstream api {
-                server api:8390;
-        }
-        server {
-              listen 4400;
-              # All API requests have a version prefix. Route everything else to
-              # the UI server.
-              location /api {
-                proxy_pass http://api;
-              }
-              location / {
-                proxy_pass http://ui;
-              }
-        }
+  # These host names are available in a docker-compose environment via
+  # docker linking.
+  upstream ui {
+    server ui:4400;
+  }
+  upstream api {
+    server api:8390;
+  }
+  server {
+    listen 4400;
+    # All API requests have a version prefix. Route everything else to
+    # the UI server.
+    location /api {
+      proxy_pass http://api;
+    }
+    location / {
+      proxy_pass http://ui;
+      # These prevent websocket 400 errors. See
+      # https://github.com/socketio/socket.io/issues/1942#issuecomment-82352072
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "Upgrade";
+      proxy_set_header Host $host;
+    }
+  }
 }


### PR DESCRIPTION
Fix WebSocket 400 errors.

1) First WebSocket error appears immediately in Console after loading localhost:4400 (desktop only):

websocket.js:6 WebSocket connection to 'ws://localhost:4400/sockjs-node/280/c4e2jj4l/websocket' failed: Error during WebSocket handshake: Unexpected response code: 400 

This PR fixes 1). 

2) Second error appears several minutes after loading localhost:4400 (laptop):

websocket.js:6 WebSocket connection to 'ws://hostname:4400/sockjs-node/159/feotusg5/websocket' failed: Error in connection establishment: net::ERR_CONNECTION_TIMED_OUT

I wasn't able to fix 2); it's probably specific to my corporate environment.

Finally, this PR cleans up indents. Prior to the PR, indentation was inconsistent throughout the file.