### PR TITLE
Print error when test data indexer fails to delete index

### DIFF
--- a/test/indexer.py
+++ b/test/indexer.py
@@ -37,7 +37,10 @@ def init_elasticsearch():
   print('Deleting and recreating %s index.' % INDEX_NAME)
   try:
     es.indices.delete(index=INDEX_NAME)
-  except Exception:
+  except Exception as e:
+    # Sometimes index exists before this script is run, and the delete fails.
+    # Print exception to help debug those cases.
+    print('Deleting test index failed: %s' % e)
     pass
   es.indices.create(index=INDEX_NAME, body={})
   return es


### PR DESCRIPTION
Occasionally after `docker-compose up`, I see:
```
index_test_data_1  | Deleting and recreating test index.
index_test_data_1  | Traceback (most recent call last):
index_test_data_1  |   File "indexer.py", line 44, in <module>
index_test_data_1  |     main()
index_test_data_1  |   File "indexer.py", line 37, in main
index_test_data_1  |     es = init_elasticsearch()
index_test_data_1  |   File "indexer.py", line 32, in init_elasticsearch
index_test_data_1  |     es.indices.create(index=INDEX_NAME, body={})
index_test_data_1  |   File "/usr/local/lib/python2.7/site-packages/elasticsearch/client/utils.py", line 76, in _wrapped
index_test_data_1  |     return func(*args, params=params, **kwargs)
index_test_data_1  |   File "/usr/local/lib/python2.7/site-packages/elasticsearch/client/indices.py", line 91, in create
index_test_data_1  |     params=params, body=body)
index_test_data_1  |   File "/usr/local/lib/python2.7/site-packages/elasticsearch/transport.py", line 314, in perform_request
index_test_data_1  |     status, headers_response, data = connection.perform_request(method, url, params, body, headers=headers, ignore=ignore, timeout=timeout)
index_test_data_1  |   File "/usr/local/lib/python2.7/site-packages/elasticsearch/connection/http_urllib3.py", line 163, in perform_request
index_test_data_1  |     self._raise_error(response.status, raw_data)
index_test_data_1  |   File "/usr/local/lib/python2.7/site-packages/elasticsearch/connection/base.py", line 125, in _raise_error
index_test_data_1  |     raise HTTP_EXCEPTIONS.get(status_code, TransportError)(status_code, error_message, additional_info)
index_test_data_1  | elasticsearch.exceptions.RequestError: TransportError(400, u'resource_already_exists_exception', u'index [test/Q5Jkt0DSQNexFNuQGReTfw] already exists')
```
It must be because [this delete](https://github.com/DataBiosphere/data-explorer/blob/mc/delete-index-logging/test/indexer.py#L39) fails. Add logging to help debug.