### PR TITLE
Allow empty query strings

### DIFF
--- a/api/data_explorer/controllers/facets_controller.py
+++ b/api/data_explorer/controllers/facets_controller.py
@@ -44,7 +44,7 @@ def deserialize(filter_arr):
     A facet_name may be repeated if multiple filters are desired.
     :return: A dict of facet_name:[facet_value] mappings.
     """
-    if not filter_arr or not ' '.join(filter_arr):
+    if not filter_arr or filter_arr == [""]:
         return {}
     parsed_filter = {}
     # filter_str looks like "Gender=male"

--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -95,9 +95,9 @@ class App extends Component {
             this.filterMap.set(facetName, this.removeFacet(currentFacetValues, facetValue));
         }
         
-        let filterString = this.filterMapToArray(this.filterMap);
-        if (filterString) {
-            this.facetsApi.facetsGet({filter: filterString}, this.facetsCallback);
+        let filterArray = this.filterMapToArray(this.filterMap);
+        if (filterArray) {
+            this.facetsApi.facetsGet({filter: filterArray}, this.facetsCallback);
         } else {
             this.facetsApi.facetsGet({}, this.facetsCallback)
         }


### PR DESCRIPTION
Fixes a bug where checking and unchecking all boxes would send a request containing empty query string instead of a `None`. Fixed the front end to not send a `filters` query param if no filters are present, and also made the back end robust enough to handle empty query params.