### PR TITLE
Export to Saturn static button

### DIFF
--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -1,6 +1,7 @@
 import './App.css';
 import { ApiClient, DatasetApi, FacetsApi } from 'data_explorer_service';
 import DatasetResponse from "./api/src/model/DatasetResponse";
+import ExportFab from "./components/ExportFab";
 import FacetsGrid from "./components/FacetsGrid";
 import Header from "./components/Header";
 
@@ -53,6 +54,7 @@ class App extends Component {
                         facets={this.state.facets}
                         totalCount={this.state.totalCount}
                     />
+                    <ExportFab></ExportFab>
                 </div>
             </MuiThemeProvider>
         );

--- a/ui/src/components/ExportFab.css
+++ b/ui/src/components/ExportFab.css
@@ -1,0 +1,8 @@
+.exportFab {
+    margin: 0px;
+    top: auto;
+    right: 20px;
+    bottom: 20px;
+    left: auto;
+    position: fixed;
+}

--- a/ui/src/components/ExportFab.js
+++ b/ui/src/components/ExportFab.js
@@ -1,0 +1,18 @@
+/** Export to Saturn FAB */
+
+import './ExportFab.css';
+
+import FileCloudUpload from 'material-ui/svg-icons/file/cloud-upload';
+import { FloatingActionButton } from "material-ui";
+import React from 'react';
+import {white} from 'material-ui/styles/colors';
+
+function ExportFab(props) {
+    return (
+        <FloatingActionButton className="exportFab">
+            <FileCloudUpload color={white} />
+        </FloatingActionButton>
+    );
+}
+
+export default ExportFab;


### PR DESCRIPTION
FAB tooltips aren't implemented [until Material v1](https://github.com/mui-org/material-ui/issues/2230#issuecomment-331586991), so let's leave out tooltip for now.

![fab](https://user-images.githubusercontent.com/10929390/38119710-9b668baa-3378-11e8-9495-2bb7994f5c9d.png)
