### PR TITLE
Add .gitattributes to ignore generated diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Don't show diffs for generated files in github.
+api/data_explorer/models/** linguist-generated=true
+api/data_explorer/swagger/** linguist-generated=true
+ui/src/api/** linguist-generated=true


### PR DESCRIPTION
In github, instead of showing the diff, it will show "Some generated files are not rendered by default".

![linguist](https://user-images.githubusercontent.com/10929390/38145967-b422d3e6-3400-11e8-8acd-27b67044289d.png)
