### PR TITLE
Restrict local servers to localhost

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     # Child services must have links named "ui", "api".
     image: nginx
     ports:
-      - 4400:4400
+      - 127.0.0.1:4400:4400
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf
     links:
@@ -23,7 +23,7 @@ services:
       context: .
       dockerfile: api/Dockerfile
     ports:
-      - 8390:8390
+      - 127.0.0.1:8390:8390
     volumes:
       # Mount the python source so that code changes don't require rebuilding
       # the image. Changes to requirements.txt will still require rebuilds.
@@ -33,11 +33,11 @@ services:
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.2
     ports:
-      - 9200:9200
+      - 127.0.0.1:9200:9200
   kibana:
     image: docker.elastic.co/kibana/kibana-oss:6.2.2
     ports:
-      - 5601:5601
+      - 127.0.0.1:5601:5601
   # For convenience, load test data into Elasticsearch.
   index_test_data:
     build:


### PR DESCRIPTION
If someone is running a local Data explorer with private data, others can't access it over the network. 

Before this PR, localhost:4400 and HOSTNAME:4400 worked. Now only localhost:4400 works.