### PR TITLE
Minor cosmetic tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,10 @@ wget http://central.maven.org/maven2/io/swagger/swagger-codegen-cli/2.3.1/swagge
 brew install swagger-codegen
 ```
 
+* In `ui/` run `npm install`. This will install tools used during git precommit,
+  such as formatting tools.
 * [Set up git secrets.](https://github.com/DataBiosphere/data-explorer/tree/master/hooks)
 
 ### Formatting
 
-The `/ui` repository is formatted via [Prettier](https://prettier.io/). husky is used to automatically format files upon commit.
+`ui/` is formatted via [Prettier](https://prettier.io/). husky is used to automatically format files upon commit.

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:2
 
-RUN pip install elasticsearch
+RUN pip install elasticsearch jsmin
 
 WORKDIR /app
 COPY . /app

--- a/test/indexer.py
+++ b/test/indexer.py
@@ -15,6 +15,7 @@ https://stackoverflow.com/questions/23798433/json-bulk-import-to-elasticstearch.
 So write a Python script.
 """
 
+import jsmin
 import json
 import time
 
@@ -54,7 +55,9 @@ def main():
   es = init_elasticsearch()
   actions = []
   with open('test.json') as f:
-    records = json.load(f)
+    # Remove comments using jsmin, as recommended by JSON creator
+    # (https://plus.google.com/+DouglasCrockfordEsq/posts/RK8qyGVaGSr).
+    records = json.loads(jsmin.jsmin(f.read()))
     for record in records:
       action = {
         '_index': INDEX_NAME,

--- a/test/test.json
+++ b/test/test.json
@@ -1,10 +1,12 @@
 [
   {
+    // Remove Smoker so we can test that facet card total count is computed
+    // computed correctly. Smoker card will show 1337; other cards will show
+    // 1338.
     "Age": 19,
     "Gender": "female",
     "BMI": 27.9,
     "Children": 0,
-    "Smoker": "yes",
     "Region": "southwest",
     "Charges": 16884.924
   },

--- a/ui/src/components/FacetCard.css
+++ b/ui/src/components/FacetCard.css
@@ -3,6 +3,15 @@
   padding-bottom: 8px;
 }
 
+.cardHeader {
+  padding: 15px;
+}
+
+.totalFacetValueCount {
+  color: gray;
+  float: right;
+}
+
 .facetValueName {
   float: left;
   text-align: left;
@@ -11,23 +20,6 @@
 .facetValueCount {
   float: right;
   text-align: right;
-}
-
-.cardHeader {
-  padding: 15px;
-}
-
-.subHeader {
-  margin-top: 5px;
-  color: gray;
-}
-
-.totalCount {
-  float: left;
-}
-
-.numberSelected {
-  float: right;
 }
 
 .grayText {

--- a/ui/src/components/FacetCard.css
+++ b/ui/src/components/FacetCard.css
@@ -4,7 +4,9 @@
 }
 
 .cardHeader {
-  padding: 15px;
+  padding-left: 15px;
+  padding-right: 15px;
+  padding-top: 15px;
 }
 
 .totalFacetValueCount {

--- a/ui/src/components/FacetCard.js
+++ b/ui/src/components/FacetCard.js
@@ -10,20 +10,19 @@ class FacetCard extends Component {
     super(props);
 
     this.facetValues = this.props.facet.values;
-    this.totalCount = this.props.totalCount;
 
     this.state = {
       selectedValues: []
     };
 
-    this.facetCount = this.sumFacetValueCounts(this.props.facet.values, []);
+    this.totalFacetValueCount = this.sumFacetValueCounts(this.props.facet.values, []);
 
     this.onValueCheck = this.onValueCheck.bind(this);
     this.isDimmed = this.isDimmed.bind(this);
   }
 
   componentWillReceiveProps(nextProps) {
-    this.facetCount = this.sumFacetValueCounts(
+    this.totalFacetValueCount = this.sumFacetValueCounts(
       nextProps.facet.values,
       this.state.selectedValues
     );
@@ -52,13 +51,8 @@ class FacetCard extends Component {
     return (
       <Card className="facetCard">
         <div className="cardHeader">
-          <div>{this.props.facet.name}</div>
-          <div className="subHeader">
-            <span>{this.facetCount}</span>
-            <span className="numberSelected">
-              {this.state.selectedValues.length} / {facetValues.length}
-            </span>
-          </div>
+          <span>{this.props.facet.name}</span>
+          <span className="totalFacetValueCount">{this.totalFacetValueCount}</span>
         </div>
         <List>{facetValues}</List>
       </Card>

--- a/ui/src/components/Header.css
+++ b/ui/src/components/Header.css
@@ -17,7 +17,7 @@
 
 .totalCountText {
   font-size: 25px !important;
-  text-align: center;
+  text-align: right;
 }
 
 .separator {


### PR DESCRIPTION
* Right-align total count
* Move Facet card total to top right
* Get rid of # facets values selected (2/5)

Also
* Add `npm install` to README One-time setup
* Remove Smoker status from first test participant, so we can test card counts are computed correctly

![cosmetic](https://user-images.githubusercontent.com/10929390/38326861-ba491b50-37fb-11e8-9136-8a482ef051ae.png)
