### PR TITLE
Return facets in the order they're found in the config

### DIFF
--- a/api/data_explorer/dataset_faceted_search.py
+++ b/api/data_explorer/dataset_faceted_search.py
@@ -6,6 +6,7 @@ import json
 
 from flask import current_app
 
+from collections import OrderedDict
 from elasticsearch import Elasticsearch
 from elasticsearch_dsl import HistogramFacet
 from elasticsearch_dsl import FacetedSearch
@@ -56,7 +57,7 @@ def get_facets():
     using = Elasticsearch(current_app.config['ELASTICSEARCH_URL'])
     mapping = Mapping.from_es(current_app.config['INDEX_NAME'], 'type',
             using=using).to_dict()
-    facets = {}
+    facets = OrderedDict()
     for facet_row in facet_rows:
         field_name = facet_row['readable_field_name']
         field_type = mapping['type']['properties'][field_name]['type']


### PR DESCRIPTION
Changing the `current_app.config['ELASTICSEARCH_FACETS']` to be an `OrderedDict` instead of a regular `dict` ensures that we can access the list of facets in the same order we input them in (one row at a time in the CSV). `elasticsearch-dsl` provides some kind of sort functionality, but it's unclear what this does or how it would work for us given that the `Response` object from calling `search.execute()` always returns a `dict` of facets, which is by definition, unordered. 