### PR TITLE
 Fix .circleci/config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 jobs:
-  ui:
+  build:
     docker:
       - image: circleci/classic:latest
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/classic:latest
+      - image: node
     steps:
       - checkout
       - run: echo "A first hello"


### PR DESCRIPTION
This time, I verified by running "circleci build" locally.
Job Manager uses "machine" for running docker inside docker (dsub local). CH recommends we use "docker".