### PR TITLE
Fix flakiness with end-to-end test

### DIFF
--- a/ui/jest-puppeteer.config.js
+++ b/ui/jest-puppeteer.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  launch: {
+//    Uncomment to see console.log executed in browser execution context.
+//    dumpio: true,
+//    Uncomment to see browser.
+//    headless: false,
+//    Uncomment to slow down execution. Unit is ms. Note that until 
+//    https://github.com/smooth-code/jest-puppeteer/issues/36 is fixed, tests
+//    will fail.
+//    slowMo: 1000,
+  },
+}

--- a/ui/jest-puppeteer.config.js
+++ b/ui/jest-puppeteer.config.js
@@ -1,12 +1,12 @@
 module.exports = {
   launch: {
-//    Uncomment to see console.log executed in browser execution context.
-//    dumpio: true,
-//    Uncomment to see browser.
-//    headless: false,
-//    Uncomment to slow down execution. Unit is ms. Note that until 
-//    https://github.com/smooth-code/jest-puppeteer/issues/36 is fixed, tests
-//    will fail.
-//    slowMo: 1000,
-  },
-}
+    //    Uncomment to see console.log executed in browser execution context.
+    //    dumpio: true,
+    //    Uncomment to see browser.
+    //    headless: false,
+    //    Uncomment to slow down execution. Unit is ms. Note that until
+    //    https://github.com/smooth-code/jest-puppeteer/issues/36 is fixed,
+    //    tests will fail.
+    //    slowMo: 1000,
+  }
+};

--- a/ui/tests/e2e/test.js
+++ b/ui/tests/e2e/test.js
@@ -1,7 +1,7 @@
 describe("End-to-end", () => {
   beforeAll(async () => {
-  await page.goto("http://localhost:4400");
-  await page.waitForSelector("span.datasetName")
+    await page.goto("http://localhost:4400");
+    await page.waitForSelector("span.datasetName");
   });
 
   test("Header", async () => {
@@ -19,7 +19,7 @@ describe("End-to-end", () => {
     await facetValueRow.click("input");
     // After data is returned from backend, Smoker facet will have "107".
     // See #63 for why we can't simply wait for div.grayText.
-    await page.waitForXPath("//text()[contains(.,'107')]")
+    await page.waitForXPath("//text()[contains(.,'107')]");
 
     // Assert page updated correctly
     await assertHeaderTotalCount("137");

--- a/ui/tests/e2e/test.js
+++ b/ui/tests/e2e/test.js
@@ -17,9 +17,9 @@ describe("End-to-end", () => {
     // Click first Age facet value
     let facetValueRow = await getFacetValueRow("Age", "10-19");
     await facetValueRow.click("input");
-    // After data is returned from backend, Smoker facet will have "107".
-    // See #63 for why we can't simply wait for div.grayText.
-    await page.waitForXPath("//text()[contains(.,'107')]");
+    // Wait for data to be returned from backend.
+    // See #63 for why we can't wait for div.grayText.
+    await page.waitForXPath("//div[contains(@class, 'totalCountText') and text() = '137']");
 
     // Assert page updated correctly
     await assertHeaderTotalCount("137");

--- a/ui/tests/e2e/test.js
+++ b/ui/tests/e2e/test.js
@@ -1,6 +1,7 @@
 describe("End-to-end", () => {
   beforeAll(async () => {
-    await page.goto("http://localhost:4400");
+  await page.goto("http://localhost:4400");
+  await page.waitForSelector("span.datasetName")
   });
 
   test("Header", async () => {
@@ -16,6 +17,9 @@ describe("End-to-end", () => {
     // Click first Age facet value
     let facetValueRow = await getFacetValueRow("Age", "10-19");
     await facetValueRow.click("input");
+    // After data is returned from backend, Smoker facet will have "107".
+    // See #63 for why we can't simply wait for div.grayText.
+    await page.waitForXPath("//text()[contains(.,'107')]")
 
     // Assert page updated correctly
     await assertHeaderTotalCount("137");

--- a/ui/tests/e2e/test.js
+++ b/ui/tests/e2e/test.js
@@ -19,7 +19,9 @@ describe("End-to-end", () => {
     await facetValueRow.click("input");
     // Wait for data to be returned from backend.
     // See #63 for why we can't wait for div.grayText.
-    await page.waitForXPath("//div[contains(@class, 'totalCountText') and text() = '137']");
+    await page.waitForXPath(
+      "//div[contains(@class, 'totalCountText') and text() = '137']"
+    );
 
     // Assert page updated correctly
     await assertHeaderTotalCount("137");


### PR DESCRIPTION
Occasionally test failed with:
```
 FAIL  tests/e2e/test.js
  End-to-end
    ✓ Header (484ms)
    ✓ Age facet (6ms)
    ✕ Faceted search (48ms)

  ● End-to-end › Faceted search

    expect(received).toBe(expected) // Object.is equality
    
    Expected value to be:
      "137"
    Received:
      "1338"

      31 |   async function assertHeaderTotalCount(count) {
      32 |     const totalCount = await page.$eval("div.totalCountText", e => e.
innerText);
    > 33 |     await expect(totalCount).toBe(count);
      34 |   }
      35 | 
      36 |   async function assertFacet(
      
      at _callee5$ (tests/e2e/test.js:33:36)
      at tryCatch (node_modules/regenerator-runtime/runtime.js:62:40)
      at Generator.invoke [as _invoke] (node_modules/regenerator-runtime/runtime
.js:296:22)
      at Generator.prototype.(anonymous function) [as next] (node_modules/regene
rator-runtime/runtime.js:114:21)
      at step (tests/e2e/test.js:1:225)
      at tests/e2e/test.js:1:385
```
I was able to repro consistently by putting `import time; time.sleep(1)` into `facets_controller.py facets_get()`.