### PR TITLE
Rename api service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Data explorer
 
+[![CircleCI](https://circleci.com/gh/DataBiosphere/data-explorer.svg?style=svg)](https://circleci.com/gh/DataBiosphere/data-explorer)
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
 
 ## Quickstart
@@ -54,6 +55,8 @@ update the server implementations:
 
 ### One-time setup
 
+* Change `vm.max_map_count`. This is needed for running Elasticsearch locally.
+  Add `vm.max_map_count=262144` to `/etc/sysctl.conf`.
 * Install `swagger-codegen-cli.jar`.
 
 ```

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ update the server implementations:
 ### One-time setup
 
 * Change `vm.max_map_count`. This is needed for running Elasticsearch locally.
-  Add `vm.max_map_count=262144` to `/etc/sysctl.conf`.
+  Add `vm.max_map_count=262144` to `/etc/sysctl.conf`. Then run `sysctl -p`.
 * Install `swagger-codegen-cli.jar`.
 
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
 version: '3'
 services:
   nginx_proxy:
-    # Child services must have links named "ui", "api".
     image: nginx
     ports:
       - 127.0.0.1:4400:4400
@@ -9,7 +8,7 @@ services:
       - ./nginx.conf:/etc/nginx/nginx.conf
     links:
       - ui
-      - api
+      - apise
   ui:
     build:
       context: ui
@@ -17,7 +16,9 @@ services:
       - ./ui:/ui
       # See https://stackoverflow.com/a/32785014 for why this is needed.
       - /ui/node_modules
-  api:
+  # Can't use "api" because it maps to something else on Google network.
+  # Use "apise" for "api server". ("apis" is also taken.)
+  apise:
     # Build Dockerfile from repo root - not api/ - since config/ is in repo root
     build:
       context: .

--- a/nginx.conf
+++ b/nginx.conf
@@ -11,7 +11,7 @@ http {
     server ui:4400;
   }
   upstream api {
-    server api:8390;
+    server apise:8390;
   }
   server {
     listen 4400;


### PR DESCRIPTION
Google recently changed its internal network to map "api" to an IP. This means we can't use "api" as a service name in docker-compose.yml.