### PR TITLE
Use DATASET_CONFIG_DIR instead of current symlink

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
           command: |
               # Needed for elasticsearch
               sudo sysctl -w vm.max_map_count=262144
-              cd ../.. && docker-compose up --build -d
+              docker-compose up --build -d
       - run:
           name: Run e2e tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,14 +44,13 @@ jobs:
           name: Run API server unit tests
           command: |
               pip install tox
-              cd api/dataset_config && ln -s test_dataset current
-              cd .. && tox
+              cd api
+              tox
       - run:
           name: Run docker-compose
           command: |
               # Needed for elasticsearch
               sudo sysctl -w vm.max_map_count=262144
-              cd api/dataset_config && ln -s test_dataset current
               cd ../.. && docker-compose up --build -d
       - run:
           name: Run e2e tests

--- a/README.md
+++ b/README.md
@@ -5,28 +5,29 @@
 
 ## Quickstart
 
-Run Data explorer with a test dataset:
+Run local Data explorer with a test dataset:
 
 * `docker-compose up --build`
 * Navigate to `localhost:4400`
 
-To use a different dataset:
+## Run local Data explorer with a specific dataset
 
-* For each dataset, there is a directory in `api/dataset_config`, e.g.
-  `api/dataset_config/amp_pd`.
-    * If you used https://github.com/DataBiosphere/data-explorer-indexers to
-      index your dataset, we recommend moving your dataset config directory from
-      that repo to `api/dataset_config/MY_DATASET`. If you need to run
-      more commands in the `data-explorer-indexers` repo, you can simply refer
-      to `api/dataset_config/MY_DATASET` in this repo.
-* Index your data into Elasticsearch. You can use one of the indexers at
-  https://github.com/DataBiosphere/data-explorer-indexers, or any other indexer.
-  https://github.com/DataBiosphere/data-explorer-indexers explains how to
-  set up the config files. Specifically:
-  * There must be a file named `dataset.json` that has a `name` field. This
-    determines the name of the Elasticsearch index.
-  * There must be a file named `facet_fields.csv` with the `readable_field_name`
-    column filled out.
+This repo contains an API server that reads from Elasticsearch, and a UI server
+that calls the API server. When running the UI and API servers, it is assumed
+that the dataset has already been indexed into Elasticsearch.
+
+To index your dataset into Elasticsearch, you can use one of the indexers at
+https://github.com/DataBiosphere/data-explorer-indexers, or any other indexer.
+
+* Index your data into Elasticsearch.
+* Create a directory in `api/dataset_config`, e.g. `api/dataset_config/amp_pd`.
+    * If you used https://github.com/DataBiosphere/data-explorer-indexers, copy
+    the config directory from there.
+    * If you used your own indexer, the config files must follow
+    this format ([see examples](https://github.com/DataBiosphere/data-explorer-indexers/tree/master/bigquery/dataset_config/platinum_genomes)):
+      * `dataset.json` has a `name` field. This determines the name of the Elasticsearch index.
+      * `facet_fields.csv` has the `readable_field_name` column filled out.
+
 * `DATASET_CONFIG_DIR=/app/dataset_config/<my dataset> docker-compose up --build`
 * Navigate to `localhost:4400`
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To index your dataset into Elasticsearch, you can use one of the indexers at
 https://github.com/DataBiosphere/data-explorer-indexers, or any other indexer.
 
 * Index your data into Elasticsearch.
-* Create a directory in `api/dataset_config`, e.g. `api/dataset_config/amp_pd`.
+* Create `api/dataset_config/<my dataset>`.
     * If you used https://github.com/DataBiosphere/data-explorer-indexers, copy
     the config directory from there.
     * If you used your own indexer, the config files must follow

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ that the dataset has already been indexed into Elasticsearch.
 To index your dataset into Elasticsearch, you can use one of the indexers at
 https://github.com/DataBiosphere/data-explorer-indexers, or any other indexer.
 
-* Index your data into Elasticsearch.
+* Index your dataset into Elasticsearch.
 * Create `api/dataset_config/<my dataset>`
     * If you used https://github.com/DataBiosphere/data-explorer-indexers, copy
     the config directory from there.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To use a different dataset:
   * There must be a file named `dataset.json` that has a `name` field. This
     determines the name of the Elasticsearch index.
   * There must be a file named `facet_fields.csv` with the `readable_field_name`
-    column filled out.
+    column filled out.  
   To confirm that your dataset is indexed, navigate to `localhost:9200/_/indices?v`.
   You should see a line for your dataset.
 * `DATASET_CONFIG_DIR=/app/dataset_config/<my dataset> docker-compose up --build`

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To index your dataset into Elasticsearch, you can use one of the indexers at
 https://github.com/DataBiosphere/data-explorer-indexers, or any other indexer.
 
 * Index your data into Elasticsearch.
-* Create `api/dataset_config/<my dataset>`.
+* Create `api/dataset_config/<my dataset>`
     * If you used https://github.com/DataBiosphere/data-explorer-indexers, copy
     the config directory from there.
     * If you used your own indexer, the config files must follow

--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@
 
 Run Data explorer with a test dataset:
 
-* `cd api/dataset_config && ln -s test_dataset current`
-* `cd ../.. && docker-compose up --build`
+* `docker-compose up --build`
 * Navigate to `localhost:4400`
 
 To use a different dataset:
@@ -20,7 +19,6 @@ To use a different dataset:
       that repo to `api/dataset_config/MY_DATASET`. If you need to run
       more commands in the `data-explorer-indexers` repo, you can simply refer
       to `api/dataset_config/MY_DATASET` in this repo.
-* Create symlink: `cd api/dataset_config && ln -s MY_DATASET current`
 * Index your data into an Elasticsearch started by
   `docker run -p 9200:9200 docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.2`. You can use one of the indexers at
   https://github.com/DataBiosphere/data-explorer-indexers, or any other indexer.
@@ -30,7 +28,7 @@ To use a different dataset:
     determines the name of the Elasticsearch index.
   * There must be a file named `facet_fields.csv` with the `readable_field_name`
     column filled out.
-* `docker-compose up --build`
+* `DATASET_CONFIG_DIR=/app/dataset_config/<my dataset> docker-compose up --build`
 * Navigate to `localhost:4400`
 
 ## Architecture overview
@@ -105,8 +103,7 @@ These tests use the [test dataset in test/](https://github.com/DataBiosphere/dat
 To run locally:
 
 ```
-cd api/dataset_config && ln -s test_dataset current
-cd ../.. && docker-compose up --build
+docker-compose up --build
 cd ui && npm run test:e2e
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,18 +12,18 @@ Run local Data Explorer with a test dataset:
 
 ## Run local Data Explorer with a custom dataset
 
-Before you can run the servers in this repo to display a Data Explorer UI,
+* Index your dataset into Elasticsearch.  
+  Before you can run the servers in this repo to display a Data Explorer UI,
 your dataset must be indexed into Elasticsearch.
-
-* Index your dataset into Elasticsearch. You can use one of the indexers at
+  You can use one of the indexers at
 https://github.com/DataBiosphere/data-explorer-indexers, or any other indexer.
 * Create `api/dataset_config/<my dataset>`
-    * If you used https://github.com/DataBiosphere/data-explorer-indexers, copy
+  * If you used https://github.com/DataBiosphere/data-explorer-indexers, copy
     the config directory from there.
-    * If you used your own indexer, the config files must follow
+  * If you used your own indexer, the config files must follow
     this format ([see examples](https://github.com/DataBiosphere/data-explorer-indexers/tree/master/bigquery/dataset_config/platinum_genomes)). Specifically:
-      * `dataset.json` has a `name` field.
-      * `facet_fields.csv` has the `readable_field_name` column filled out.
+    * `dataset.json` has a `name` field.
+    * `facet_fields.csv` has the `readable_field_name` column filled out.
 
 * `DATASET_CONFIG_DIR=/app/dataset_config/<my dataset> docker-compose up --build`
 * Navigate to `localhost:4400`

--- a/README.md
+++ b/README.md
@@ -5,27 +5,24 @@
 
 ## Quickstart
 
-Run local Data explorer with a test dataset:
+Run local Data Explorer with a test dataset:
 
 * `docker-compose up --build`
 * Navigate to `localhost:4400`
 
-## Run local Data explorer with a specific dataset
+## Run local Data Explorer with a specific dataset
 
-This repo contains an API server that reads from Elasticsearch, and a UI server
-that calls the API server. When running the UI and API servers, it is assumed
-that the dataset has already been indexed into Elasticsearch.
+Before you can run the servers in this repo to display a Data Explorer UI,
+your dataset must be indexed into Elasticsearch.
 
-To index your dataset into Elasticsearch, you can use one of the indexers at
+* Index your dataset into Elasticsearch. You can use one of the indexers at
 https://github.com/DataBiosphere/data-explorer-indexers, or any other indexer.
-
-* Index your dataset into Elasticsearch.
 * Create `api/dataset_config/<my dataset>`
     * If you used https://github.com/DataBiosphere/data-explorer-indexers, copy
     the config directory from there.
     * If you used your own indexer, the config files must follow
-    this format ([see examples](https://github.com/DataBiosphere/data-explorer-indexers/tree/master/bigquery/dataset_config/platinum_genomes)):
-      * `dataset.json` has a `name` field. This determines the name of the Elasticsearch index.
+    this format ([see examples](https://github.com/DataBiosphere/data-explorer-indexers/tree/master/bigquery/dataset_config/platinum_genomes)). Specifically:
+      * `dataset.json` has a `name` field.
       * `facet_fields.csv` has the `readable_field_name` column filled out.
 
 * `DATASET_CONFIG_DIR=/app/dataset_config/<my dataset> docker-compose up --build`

--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ To use a different dataset:
       that repo to `api/dataset_config/MY_DATASET`. If you need to run
       more commands in the `data-explorer-indexers` repo, you can simply refer
       to `api/dataset_config/MY_DATASET` in this repo.
-* Index your data into an Elasticsearch started by
-  `docker run -p 9200:9200 docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.2`. You can use one of the indexers at
+* Index your data into Elasticsearch. You can use one of the indexers at
   https://github.com/DataBiosphere/data-explorer-indexers, or any other indexer.
   https://github.com/DataBiosphere/data-explorer-indexers explains how to
   set up the config files. Specifically:
@@ -28,6 +27,8 @@ To use a different dataset:
     determines the name of the Elasticsearch index.
   * There must be a file named `facet_fields.csv` with the `readable_field_name`
     column filled out.
+  To confirm that your dataset is indexed, navigate to `localhost:9200/_/indices?v`.
+  You should see a line for your dataset.
 * `DATASET_CONFIG_DIR=/app/dataset_config/<my dataset> docker-compose up --build`
 * Navigate to `localhost:4400`
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Run local Data Explorer with a test dataset:
 * `docker-compose up --build`
 * Navigate to `localhost:4400`
 
-## Run local Data Explorer with a specific dataset
+## Run local Data Explorer with a custom dataset
 
 Before you can run the servers in this repo to display a Data Explorer UI,
 your dataset must be indexed into Elasticsearch.

--- a/README.md
+++ b/README.md
@@ -26,9 +26,7 @@ To use a different dataset:
   * There must be a file named `dataset.json` that has a `name` field. This
     determines the name of the Elasticsearch index.
   * There must be a file named `facet_fields.csv` with the `readable_field_name`
-    column filled out.  
-  To confirm that your dataset is indexed, navigate to `localhost:9200/_/indices?v`.
-  You should see a line for your dataset.
+    column filled out.
 * `DATASET_CONFIG_DIR=/app/dataset_config/<my dataset> docker-compose up --build`
 * Navigate to `localhost:4400`
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 ADD requirements.txt /app
 RUN pip install -r requirements.txt
 
-COPY dataset_config/current /app/dataset_config
+COPY dataset_config /app/dataset_config
 COPY data_explorer /app/data_explorer
 
 ENTRYPOINT ["gunicorn", "data_explorer.__main__:app"]

--- a/api/app.yaml
+++ b/api/app.yaml
@@ -6,4 +6,5 @@ entrypoint: gunicorn -b ":$PORT" data_explorer.__main__:app
 env_variables:
   PATH_PREFIX: /api
   ELASTICSEARCH_URL: http://ELASTICSEARCH_URL:9200/
-  DATASET_CONFIG_DIR: /app/dataset_config/platinum_genomes
+  # Example: /app/dataset_config/platinum_genomes
+  DATASET_CONFIG_DIR: /app/dataset_config/MY_DATASET

--- a/api/app.yaml
+++ b/api/app.yaml
@@ -5,5 +5,5 @@ entrypoint: gunicorn -b ":$PORT" data_explorer.__main__:app
 
 env_variables:
   PATH_PREFIX: /api
-  ELASTICSEARCH_URL: http://10.128.0.7:9200/
+  ELASTICSEARCH_URL: http://ELASTICSEARCH_URL:9200/
   DATASET_CONFIG_DIR: /app/dataset_config/platinum_genomes

--- a/api/app.yaml
+++ b/api/app.yaml
@@ -6,5 +6,4 @@ entrypoint: gunicorn -b ":$PORT" data_explorer.__main__:app
 env_variables:
   PATH_PREFIX: /api
   ELASTICSEARCH_URL: http://ELASTICSEARCH_URL:9200/
-  # Example: /app/dataset_config/platinum_genomes
   DATASET_CONFIG_DIR: /app/dataset_config/MY_DATASET

--- a/api/app.yaml
+++ b/api/app.yaml
@@ -5,5 +5,5 @@ entrypoint: gunicorn -b ":$PORT" data_explorer.__main__:app
 
 env_variables:
   PATH_PREFIX: /api
-  ELASTICSEARCH_URL: http://ELASTICSEARCH_URL:9200/
-  DATASET_CONFIG_DIR: /app/dataset_config
+  ELASTICSEARCH_URL: http://10.128.0.7:9200/
+  DATASET_CONFIG_DIR: /app/dataset_config/platinum_genomes

--- a/api/data_explorer/test/test_dataset_controller.py
+++ b/api/data_explorer/test/test_dataset_controller.py
@@ -9,7 +9,7 @@ class TestDatasetController(BaseTestCase):
     def create_app(self):
         app = super(TestDatasetController, self).create_app()
         app.config.update({
-            'DATASET_CONFIG_DIR': 'dataset_config/current',
+            'DATASET_CONFIG_DIR': 'dataset_config/test_dataset',
         })
         return app
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -40,7 +40,7 @@ domain name: `https://PROJECT_ID.appspot.com`
 
 ### Deploy the API Server
 
-* Set DATASET_CONFIG_DIR in `app.yaml`
+* Set MY_DATASET in `app.yaml`
   * If you are deploying the [default platinum_genomes dataset from the
     data-explorer-indexers repo](https://github.com/DataBiosphere/data-explorer-indexers/tree/master/bigquery/config/platinum_genomes),
     please create `api/dataset_config/platinum_genomes` and copy over the

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -40,13 +40,11 @@ domain name: `https://PROJECT_ID.appspot.com`
 
 ### Deploy the API Server
 
-* Make sure that `api/dataset_config/MY_DATASET` contains your dataset config
-  files.
+* Set DATASET_CONFIG_DIR in `app.yaml`
   * If you are deploying the [default platinum_genomes dataset from the
     data-explorer-indexers repo](https://github.com/DataBiosphere/data-explorer-indexers/tree/master/bigquery/config/platinum_genomes),
     please create `api/dataset_config/platinum_genomes` and copy over the
     [config files](https://github.com/DataBiosphere/data-explorer-indexers/tree/master/bigquery/config/platinum_genomes).
-  * Change DATASET_CONFIG_DIR in `app.yaml`.
 
 * Find the `ELASTICSEARCH_URL`. Run `kubectl get svc`, look for `elasticsearch`
 row, `EXTERNAL-IP` column. Note that because the Elasticsearch deployment uses

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -40,14 +40,13 @@ domain name: `https://PROJECT_ID.appspot.com`
 
 ### Deploy the API Server
 
-* Make sure that `api/dataset_config/current` contains your dataset config
+* Make sure that `api/dataset_config/MY_DATASET` contains your dataset config
   files.
   * If you are deploying the [default platinum_genomes dataset from the
     data-explorer-indexers repo](https://github.com/DataBiosphere/data-explorer-indexers/tree/master/bigquery/config/platinum_genomes),
-    please create `api/dataset_config/platinum_genomes`, copy over the
-    [config files](https://github.com/DataBiosphere/data-explorer-indexers/tree/master/bigquery/config/platinum_genomes),
-    and make `api/dataset_config/current` a symlink to
-    `api/dataset_config/platinum_genomes`.
+    please create `api/dataset_config/platinum_genomes` and copy over the
+    [config files](https://github.com/DataBiosphere/data-explorer-indexers/tree/master/bigquery/config/platinum_genomes).
+  * Change DATASET_CONFIG_DIR in `app.yaml`.
 
 * Find the `ELASTICSEARCH_URL`. Run `kubectl get svc`, look for `elasticsearch`
 row, `EXTERNAL-IP` column. Note that because the Elasticsearch deployment uses

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
     environment:
       - ELASTICSEARCH_URL=elasticsearch:9200
       - PATH_PREFIX=/api
-      - DATASET_CONFIG_DIR=/app/dataset_config
+      - DATASET_CONFIG_DIR=${DATASET_CONFIG_DIR:-/app/dataset_config/test_dataset}
       # Avoid writing .pyc files back to the volume. Files generated this way
       # have restricted permissions set which cause errors on subsequent docker
       # builds.


### PR DESCRIPTION
current symlink works with local deployment, but doesn't work with App Engine deployment. In general, [App Engine doesn't support symlinks in docker build context](https://groups.google.com/d/msg/google-cloud-sdk/2fmY1uHNziY/9CGvPsfJCAAJ).

I think this is cleaner anyways.

Confirmed that these work:
* `docker-compose up --build`
* `DATASET_CONFIG_DIR=/app/dataset_config/platinum_genomes docker-compose up --build`
* App Engine deployment