### PR TITLE
Support expanded Elasticsearch BigQuery field names

### DIFF
--- a/dataset_config/platinum_genomes/ui.json
+++ b/dataset_config/platinum_genomes/ui.json
@@ -3,15 +3,15 @@
   "facets": [
     {
       "ui_facet_name": "Gender",
-      "elasticsearch_field_name": "gender"
+      "elasticsearch_field_name": "google.com:biggene.platinum_genomes.sample_info.gender"
     },
     {
       "ui_facet_name": "Race",
-      "elasticsearch_field_name": "race"
+      "elasticsearch_field_name": "google.com:biggene.platinum_genomes.sample_info.race"
     },
     {
       "ui_facet_name": "Relationship",
-      "elasticsearch_field_name": "relationship_to_proband"
+      "elasticsearch_field_name": "google.com:biggene.platinum_genomes.sample_info.relationship_to_proband"
     }
   ]
 }

--- a/dataset_config/test_dataset/ui.json
+++ b/dataset_config/test_dataset/ui.json
@@ -3,7 +3,7 @@
   "facets": [
     {
       "ui_facet_name": "Age",
-      "elasticsearch_field_name": "Age"
+      "elasticsearch_field_name": "Agsdfsdfe"
     },
     {
       "ui_facet_name": "Gender",

--- a/dataset_config/test_dataset/ui.json
+++ b/dataset_config/test_dataset/ui.json
@@ -3,7 +3,7 @@
   "facets": [
     {
       "ui_facet_name": "Age",
-      "elasticsearch_field_name": "Agsdfsdfe"
+      "elasticsearch_field_name": "Age"
     },
     {
       "ui_facet_name": "Gender",


### PR DESCRIPTION
After https://github.com/DataBiosphere/data-explorer-indexers/pull/44, Elasticsearch index contains field names "google.com:biggene.platinum_genomes.sample_info.gender" instead of "gender". In order to support this, I had to change the way I retrieved field names from Elasticsearch.

Tested:
- Local default dataset
- Local Platinum Genomes