### PR TITLE
Export to Saturn UI functionality

### DIFF
--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -6,6 +6,7 @@ import Header from "./components/Header";
 
 import React, { Component } from "react";
 import { MuiThemeProvider } from "material-ui";
+import ExportUrlApi from "./api/src/api/ExportUrlApi";
 
 class App extends Component {
   constructor(props) {
@@ -51,7 +52,7 @@ class App extends Component {
               updateFacets={this.updateFacets}
               facets={this.state.facets}
             />
-            <ExportFab />
+            <ExportFab exportUrlApi={new ExportUrlApi(this.apiClient)} />
           </div>
         </MuiThemeProvider>
       );

--- a/ui/src/api/src/api/__mocks__/ExportUrlApi.js
+++ b/ui/src/api/src/api/__mocks__/ExportUrlApi.js
@@ -1,0 +1,16 @@
+import ExportUrlResponse from "../../model/ExportUrlResponse";
+
+export const mockExportUrlPost = jest.fn(callback => {
+  let postExportUrlResponse = new ExportUrlResponse();
+  postExportUrlResponse.url = "exportUrl";
+  callback(null, postExportUrlResponse);
+  return postExportUrlResponse;
+});
+
+const mock = jest.fn().mockImplementation(() => {
+  return {
+    exportUrlPost: mockExportUrlPost
+  };
+});
+
+export default mock;

--- a/ui/src/components/ExportFab.js
+++ b/ui/src/components/ExportFab.js
@@ -7,15 +7,40 @@ import Button from "@material-ui/core/Button";
 import Tooltip from "@material-ui/core/Tooltip";
 import React from "react";
 
-function ExportFab(props) {
-  return (
-    <Tooltip title="Export to Saturn">
-      <Button variant="fab" color="secondary" className="exportFab"
-           href="https://bvdp-saturn-prod.appspot.com/#import-data">
-        <CloudUpload />
-      </Button>
-    </Tooltip>
-  );
+class ExportFab extends React.Component {
+  constructor(props) {
+    super(props);
+    this.handleClick = this.handleClick.bind(this);
+  }
+
+  render() {
+    return (
+      <Tooltip title="Export to Saturn">
+        <Button
+          variant="fab"
+          color="secondary"
+          className="exportFab"
+          onClick={() => this.handleClick()}
+        >
+          <CloudUpload />
+        </Button>
+      </Tooltip>
+    );
+  }
+
+  handleClick() {
+    let exportUrlCallback = function(error, data) {
+      if (error) {
+        console.error(error);
+        // TODO(alanhwang): Redirect to an error page
+      } else {
+        window.location.assign(
+          "https://bvdp-saturn-prod.appspot.com/#import-data?url=" + data.url
+        );
+      }
+    }.bind(this);
+    this.props.exportUrlApi.exportUrlPost(exportUrlCallback);
+  }
 }
 
 export default ExportFab;

--- a/ui/tests/unit/__tests__/ExportFab.test.js
+++ b/ui/tests/unit/__tests__/ExportFab.test.js
@@ -1,7 +1,43 @@
 import React from "react";
 import ExportFab from "../../../src/components/ExportFab";
+import { getMuiTheme } from "material-ui/styles/index";
+import { mockExportUrlPost } from "../../../src/api/src/api/ExportUrlApi";
+import Button from "@material-ui/core/Button";
+import PropTypes from "prop-types";
+import ExportUrlApi from "../../../src/api/src/api/ExportUrlApi";
+import ApiClient from "../../../src/api/src/ApiClient";
+
+jest.mock("../../../src/api/src/api/ExportUrlApi");
+("use strict");
+
+beforeEach(() => {
+  mockExportUrlPost.mockClear();
+});
 
 test("Renders correctly", () => {
-  const tree = shallow(<ExportFab />);
+  const tree = shallow(
+    <ExportFab exportUrlApi={new ExportUrlApi(new ApiClient())} />
+  );
   expect(tree).toMatchSnapshot();
+});
+
+test("Calls API and redirects on click", () => {
+  window.location.assign = jest.fn();
+  let muiTheme = getMuiTheme();
+  const tree = mount(
+    <ExportFab exportUrlApi={new ExportUrlApi(new ApiClient())} />,
+    {
+      context: { muiTheme },
+      childContextTypes: { muiTheme: PropTypes.object }
+    }
+  );
+  let button = tree.find(Button);
+  button
+    .first()
+    .props()
+    .onClick();
+  expect(mockExportUrlPost).toHaveBeenCalledTimes(1);
+  expect(window.location.assign).toBeCalledWith(
+    "https://bvdp-saturn-prod.appspot.com/#import-data?url=exportUrl"
+  );
 });

--- a/ui/tests/unit/__tests__/ExportFab.test.js
+++ b/ui/tests/unit/__tests__/ExportFab.test.js
@@ -31,8 +31,8 @@ test("Calls API and redirects on click", () => {
       childContextTypes: { muiTheme: PropTypes.object }
     }
   );
-  let button = tree.find(Button);
-  button
+  let exportButton = tree.find(Button);
+  exportButton
     .first()
     .props()
     .onClick();

--- a/ui/tests/unit/__tests__/__snapshots__/App.test.js.snap
+++ b/ui/tests/unit/__tests__/__snapshots__/App.test.js.snap
@@ -46,7 +46,21 @@ exports[`Renders correctly after receiving all data 1`] = `
       }
       updateFacets={[Function]}
     />
-    <ExportFab />
+    <ExportFab
+      exportUrlApi={
+        ExportUrlApi {
+          "apiClient": ApiClient {
+            "authentications": Object {},
+            "basePath": "/api",
+            "cache": true,
+            "defaultHeaders": Object {},
+            "enableCookies": false,
+            "requestAgent": null,
+            "timeout": 60000,
+          },
+        }
+      }
+    />
   </div>
 </MuiThemeProvider>
 `;

--- a/ui/tests/unit/__tests__/__snapshots__/ExportFab.test.js.snap
+++ b/ui/tests/unit/__tests__/__snapshots__/ExportFab.test.js.snap
@@ -7,7 +7,7 @@ exports[`Renders correctly 1`] = `
   <WithStyles(Button)
     className="exportFab"
     color="secondary"
-    href="https://bvdp-saturn-prod.appspot.com/#import-data"
+    onClick={[Function]}
     variant="fab"
   >
     <pure(CloudUpload) />


### PR DESCRIPTION
Export to Saturn calls the exportUrlPost on click, then uses the returned url to redirect to Saturn's importData page with the returned URL.

Note that currently the "url" is just spitting out the raw json, when the API starts returning signed URLs this will work properly.