### PR TITLE
Update Export url JSON format

### DIFF
--- a/api/data_explorer/controllers/export_url_controller.py
+++ b/api/data_explorer/controllers/export_url_controller.py
@@ -1,6 +1,7 @@
 import connexion
 import six
 import json
+import os
 
 from flask import current_app
 from werkzeug.exceptions import BadRequest

--- a/api/data_explorer/controllers/export_url_controller.py
+++ b/api/data_explorer/controllers/export_url_controller.py
@@ -1,12 +1,24 @@
 import connexion
-import json
-import os
 import six
+import json
 
 from flask import current_app
 from werkzeug.exceptions import BadRequest
 
 from data_explorer.models.export_url_response import ExportUrlResponse  # noqa: E501
+
+# Export to Saturn flow
+# - User clicks export button on bottom right of Data Explorer
+# - A dialog pops up, asking user to name cohort. User types "African females"
+#   and clicks Export button
+# - UI server calls API server /export_url (this file):
+#   - Constructs a JSON array of JSON entity objects
+#   - Writes JSON array to a GCS file
+#   - Creates a signed url for GCS file. Returns signed url to UI server
+# - UI server redirects to Saturn add-import?url=SIGNED_URL
+# - On add-import page, user selects Workspace. User clicks Import button.
+# - User is redirected to selected workspace Data tab, showing newly imported
+#   entities.
 
 
 def export_url_post():  # noqa: E501
@@ -29,17 +41,30 @@ def export_url_post():  # noqa: E501
         current_app.logger.error(error_msg)
         raise BadRequest(error_msg)
 
-    requests = []
+    # Saturn add-import expects a JSON list of entities, where each entity is
+    # the entity JSON passed into
+    # https://rawls.dsde-prod.broadinstitute.org/#!/entities/create_entity
+    entities = []
     for table_name in current_app.config['TABLE_NAMES']:
-        # Treat table names as BigQuery tables if they conform to project_id.dataset.table_id
-        if len(table_name.split(".")) == 3:
-            requests.append(
-                json.dumps({
-                    "name": table_name.split(".")[2],
-                    "entityType": "BigQuery table",
-                    "attributes": {
-                        "table_name": table_name
-                    }
-                }))
+        splits = table_name.split('.')
+        if len(splits) != 3:
+            raise BadRequest(
+                'Unknown format for table name %s. Expected BigQuery project_id.dataset_id.table_name'
+            )
+        entities.append({
+            # FireCloud doesn't allow spaces, so use underscore.
+            'entityType': 'BigQuery_table',
+            # This is the entity ID. Ideally this would be
+            # project_id.dataset_id.table_name, and we wouldn't need the
+            # table_name attribute. Unfortunately RAWLS doesn't allow
+            # periods here. RAWLS does allow periods in attributes. So use
+            # underscores here and periods in table_name attribute.
+            'name': table_name.replace('.', '_'),
+            'attributes': {
+                'table_name': table_name
+            }
+        })
+    current_app.logger.info('Export URL file: %s' % json.dumps(entities))
+
     # TODO: Create a signed URL using the output of this request
-    return ExportUrlResponse(url="".join(requests))
+    return ExportUrlResponse(url='format=entitiesJson&url=Coming soon')

--- a/api/data_explorer/test/test_export_url_controller.py
+++ b/api/data_explorer/test/test_export_url_controller.py
@@ -20,14 +20,6 @@ class TestExportUrlController(BaseTestCase):
     def test_export_url_post(self):
         response = self.client.post('/exportUrl')
         self.assert200(response)
-        expected_json = {
-            "name": 'table_name',
-            "entityType": "BigQuery table",
-            "attributes": {
-                "table_name": 'project_id.dataset_id.table_name'
-            }
-        }
-        self.assertEquals(expected_json, json.loads(response.json['url']))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The Export to Saturn feature exports a JSON entity representing a BigQuery table. The JSON entity is of the format that [createEntity](https://rawls.dsde-prod.broadinstitute.org/#!/entities/create_entity) expects.

In this PR, I make some changes to the JSON format based on testing with Saturn. (The previous format was not tested with Saturn.)

CC @bfcrampton FYI