### PR TITLE
Don't move export button when opening cohort dialog

### DIFF
--- a/ui/src/components/ExportFab.css
+++ b/ui/src/components/ExportFab.css
@@ -1,8 +1,5 @@
 .exportFab {
-  margin: 0;
-  top: auto;
   right: 20px;
   bottom: 20px;
-  left: auto;
-  position: fixed !important;
+  position: fixed;
 }

--- a/ui/src/components/ExportFab.js
+++ b/ui/src/components/ExportFab.js
@@ -25,16 +25,20 @@ class ExportFab extends React.Component {
   render() {
     return (
       <div>
-        <Tooltip title="Export to Saturn">
-          <Button
-            variant="fab"
-            color="secondary"
-            className="exportFab"
-            onClick={() => this.handleClick()}
-          >
-            <CloudUpload />
-          </Button>
-        </Tooltip>
+        // Style div instead of button itself, to prevent button from moving
+        // when cohort dialog is shown. See
+        // https://github.com/mui-org/material-ui/issues/9275#issuecomment-350479467
+        <div className="mui-fixed exportFab">
+          <Tooltip title="Export to Saturn">
+            <Button
+              variant="fab"
+              color="secondary"
+              onClick={() => this.handleClick()}
+            >
+              <CloudUpload />
+            </Button>
+          </Tooltip>
+        </div>
         <div>
           <Dialog
             open={this.state.open}

--- a/ui/src/components/ExportFab.js
+++ b/ui/src/components/ExportFab.js
@@ -31,7 +31,7 @@ class ExportFab extends React.Component {
           https://github.com/mui-org/material-ui/issues/9275#issuecomment-350479467
         */}
         <div className="mui-fixed exportFab">
-          <Tooltip title="Export to Saturn">
+          <Tooltip title="Send to Saturn">
             <Button
               variant="fab"
               color="secondary"

--- a/ui/src/components/ExportFab.js
+++ b/ui/src/components/ExportFab.js
@@ -25,9 +25,11 @@ class ExportFab extends React.Component {
   render() {
     return (
       <div>
-        // Style div instead of button itself, to prevent button from moving
-        // when cohort dialog is shown. See
-        // https://github.com/mui-org/material-ui/issues/9275#issuecomment-350479467
+        {/*
+          Style div instead of button itself, to prevent button from moving
+          when cohort dialog is shown. See
+          https://github.com/mui-org/material-ui/issues/9275#issuecomment-350479467
+        */}
         <div className="mui-fixed exportFab">
           <Tooltip title="Export to Saturn">
             <Button

--- a/ui/tests/unit/__tests__/__snapshots__/ExportFab.test.js.snap
+++ b/ui/tests/unit/__tests__/__snapshots__/ExportFab.test.js.snap
@@ -2,18 +2,22 @@
 
 exports[`Renders correctly 1`] = `
 <div>
-  <WithStyles(Tooltip)
-    title="Export to Saturn"
+  // Style div instead of button itself, to prevent button from moving // when cohort dialog is shown. See // https://github.com/mui-org/material-ui/issues/9275#issuecomment-350479467
+  <div
+    className="mui-fixed exportFab"
   >
-    <WithStyles(Button)
-      className="exportFab"
-      color="secondary"
-      onClick={[Function]}
-      variant="fab"
+    <WithStyles(Tooltip)
+      title="Export to Saturn"
     >
-      <pure(CloudUpload) />
-    </WithStyles(Button)>
-  </WithStyles(Tooltip)>
+      <WithStyles(Button)
+        color="secondary"
+        onClick={[Function]}
+        variant="fab"
+      >
+        <pure(CloudUpload) />
+      </WithStyles(Button)>
+    </WithStyles(Tooltip)>
+  </div>
   <div>
     <WithStyles(Dialog)
       aria-labelledby="form-dialog-title"

--- a/ui/tests/unit/__tests__/__snapshots__/ExportFab.test.js.snap
+++ b/ui/tests/unit/__tests__/__snapshots__/ExportFab.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`Renders correctly 1`] = `
 <div>
-  // Style div instead of button itself, to prevent button from moving // when cohort dialog is shown. See // https://github.com/mui-org/material-ui/issues/9275#issuecomment-350479467
   <div
     className="mui-fixed exportFab"
   >

--- a/ui/tests/unit/__tests__/__snapshots__/ExportFab.test.js.snap
+++ b/ui/tests/unit/__tests__/__snapshots__/ExportFab.test.js.snap
@@ -6,7 +6,7 @@ exports[`Renders correctly 1`] = `
     className="mui-fixed exportFab"
   >
     <WithStyles(Tooltip)
-      title="Export to Saturn"
+      title="Send to Saturn"
     >
       <WithStyles(Button)
         color="secondary"


### PR DESCRIPTION
Also see https://github.com/mui-org/material-ui/blob/db5531a81a2653cef492c9d0bce05085ab9f1d65/docs/src/pages/getting-started/faq/faq.md#why-do-the-fixed-positioned-elements-move-when-a-modal-is-opened