### PR TITLE
Allow private key per dataset

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
           command: |
               # Some files are missing because of .gitignore
               touch dataset_config/1000_genomes/deploy.json
-              touch api/data_explorer/private-key.json
+              touch dataset_config/1000_genomes/private-key.json
               pip install tox
               cd api
               tox

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ dataset_config/*
 !dataset_config/template
 !dataset_config/1000_genomes
 dataset_config/1000_genomes/deploy.json
-api/data_explorer/private-key.json
+dataset_config/1000_genomes/private-key.json
 
 api/app.yaml
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ the directory in `dataset_config`.
 * The Export to Saturn feature creates a signed URL, which requires a service
 account private key. Follow these instructions (["Generate a new private key"](https://cloud.google.com/storage/docs/access-control/create-signed-urls-program#signing-language))
 to create the private key. Select the App Engine default service account.
-Store the key in `api/data_explorer/private-key.json`.
+Store the key in `dataset_config/DATASET/private-key.json`.
 
 ### Testing
 

--- a/api/data_explorer/controllers/export_url_controller.py
+++ b/api/data_explorer/controllers/export_url_controller.py
@@ -29,8 +29,6 @@ from data_explorer.models.export_url_response import ExportUrlResponse  # noqa: 
 # - User is redirected to selected workspace Data tab, showing newly imported
 #   entities.
 
-PRIVATE_KEY_PATH = os.path.join(os.getcwd(), 'data_explorer/private-key.json')
-
 
 def _check_preconditions():
     config_path = os.path.join(current_app.config['DATASET_CONFIG_DIR'],
@@ -60,7 +58,9 @@ def _check_preconditions():
         current_app.logger.error(error_msg)
         raise BadRequest(error_msg)
 
-    if not os.path.isfile(PRIVATE_KEY_PATH):
+    private_key_path = os.path.join(current_app.config['DATASET_CONFIG_DIR'],
+                                    'private-key.json')
+    if not os.path.isfile(private_key_path):
         error_msg = (
             'Private key not found. Export to Saturn feature will not work. '
             'See https://github.com/DataBiosphere/data-explorer#one-time-setup-for-export-to-saturn-feature'
@@ -114,7 +114,9 @@ def _write_gcs_file(entities):
 
 
 def _create_signed_url(gcs_path):
-    creds = ServiceAccountCredentials.from_json_keyfile_name(PRIVATE_KEY_PATH)
+    private_key_path = os.path.join(current_app.config['DATASET_CONFIG_DIR'],
+                                    'private-key.json')
+    creds = ServiceAccountCredentials.from_json_keyfile_name(private_key_path)
     service_account_email = current_app.config['DEPLOY_PROJECT_ID'] + '@appspot.gserviceaccount.com'
     # Signed URL will be valid for 5 minutes
     timestamp = str(int(time.time()) + 5 * 60)


### PR DESCRIPTION
Each dataset needs a private key for the App Engine service account for that dataset.

I removed PRIVATE_KEY in the controller because current_app.config was not set where PRIVATE_KEY
was defined, causing app to crash.