### PR TITLE
Minor changes to Cohort Name dialog

### DIFF
--- a/ui/src/components/ExportFab.js
+++ b/ui/src/components/ExportFab.js
@@ -58,6 +58,11 @@ class ExportFab extends React.Component {
                 helperText="A cohort with this name will be created in Saturn"
                 type="text"
                 fullWidth
+                onKeyPress={(ev) => {
+                  if (ev.key === 'Enter') {
+                    this.handleSave()
+                  }
+                }}
               />
             </DialogContent>
             <DialogActions>
@@ -65,7 +70,7 @@ class ExportFab extends React.Component {
                 Cancel
               </Button>
               <Button onClick={this.handleSave} color="primary">
-                Export
+                Send
               </Button>
             </DialogActions>
           </Dialog>

--- a/ui/tests/unit/__tests__/__snapshots__/ExportFab.test.js.snap
+++ b/ui/tests/unit/__tests__/__snapshots__/ExportFab.test.js.snap
@@ -31,6 +31,7 @@ exports[`Renders correctly 1`] = `
           label="Cohort Name"
           margin="dense"
           onChange={[Function]}
+          onKeyPress={[Function]}
           required={false}
           select={false}
           type="text"
@@ -47,7 +48,7 @@ exports[`Renders correctly 1`] = `
           color="primary"
           onClick={[Function]}
         >
-          Export
+          Send
         </WithStyles(Button)>
       </WithStyles(DialogActions)>
     </WithStyles(Dialog)>


### PR DESCRIPTION
- "Export" -> "Send" (Matt requested the feature be renamed from "Export to Saturn" to "Send to Saturn".)
- After typing cohort name, pressing Enter will Save

FYI @malathi13 