### PR TITLE
Fix boolean facets

### DIFF
--- a/api/data_explorer/controllers/facets_controller.py
+++ b/api/data_explorer/controllers/facets_controller.py
@@ -42,6 +42,10 @@ def facets_get(filter=None):  # noqa: E501
                                              es_facet._params['interval'])
                 values.append(FacetValue(name=range_str, count=count))
             else:
+                # elasticsearch-dsl returns boolean field keys as 0/1. Use the
+                # field's 'type' to convert back to boolean, if necessary.
+                if field['type'] == 'boolean':
+                    value_name = bool(value_name)
                 values.append(FacetValue(name=value_name, count=count))
         facets.append(Facet(name=name, description=description, values=values))
     return FacetsResponse(


### PR DESCRIPTION
Hey Bryan, I copied the relevant code from you PR. Thanks for fixing.

Repro:
- https://test-data-explorer.appspot.com/
- Click on `1` in `In Final Phase Variant Calling`
- API server /facets fails, UI doesn't update:
![boolbug](https://user-images.githubusercontent.com/10929390/45504664-5879cc80-b73f-11e8-9f8b-25f8484c0672.png)
API server logs:
```
nginx_proxy_1      | 172.18.0.1 - - [13/Sep/2018:16:57:25 +0000] "GET /api/facets?filter=In%20Final%20Phase%20Variant%20Calling%3D1 HTTP/1.1" 500 255 "http://localhost:4400/" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.106 Safari/537.36"
apise_1            | Exception on /api/facets [GET]
apise_1            | Traceback (most recent call last):
apise_1            |   File "/usr/local/lib/python2.7/site-packages/flask/app.py", line 2292, in wsgi_app
apise_1            |     response = self.full_dispatch_request()
apise_1            |   File "/usr/local/lib/python2.7/site-packages/flask/app.py", line 1815, in full_dispatch_request
apise_1            |     rv = self.handle_user_exception(e)
apise_1            |   File "/usr/local/lib/python2.7/site-packages/flask/app.py", line 1718, in handle_user_exception
apise_1            |     reraise(exc_type, exc_value, tb)
apise_1            |   File "/usr/local/lib/python2.7/site-packages/flask/app.py", line 1813, in full_dispatch_request
apise_1            |     rv = self.dispatch_request()
apise_1            |   File "/usr/local/lib/python2.7/site-packages/flask/app.py", line 1799, in dispatch_request
apise_1            |     return self.view_functions[rule.endpoint](**req.view_args)
apise_1            |   File "/usr/local/lib/python2.7/site-packages/connexion/decorators/decorator.py", line 66, in wrapper
apise_1            |     response = function(request)
apise_1            |   File "/usr/local/lib/python2.7/site-packages/connexion/decorators/validation.py", line 293, in wrapper
apise_1            |     return function(request)
apise_1            |   File "/usr/local/lib/python2.7/site-packages/connexion/decorators/decorator.py", line 42, in wrapper
apise_1            |     response = function(request)
apise_1            |   File "/usr/local/lib/python2.7/site-packages/connexion/decorators/parameter.py", line 195, in wrapper
apise_1            |     return function(**kwargs)
apise_1            |   File "/app/data_explorer/controllers/facets_controller.py", line 80, in facets_get
apise_1            |     es_response = search.execute()
apise_1            |   File "/usr/local/lib/python2.7/site-packages/elasticsearch_dsl/faceted_search.py", line 351, in execute
apise_1            |     r = self._s.execute()
apise_1            |   File "/usr/local/lib/python2.7/site-packages/elasticsearch_dsl/search.py", line 679, in execute
apise_1            |     **self._params
apise_1            |   File "/usr/local/lib/python2.7/site-packages/elasticsearch/client/utils.py", line 76, in _wrapped
apise_1            |     return func(*args, params=params, **kwargs)
apise_1            |   File "/usr/local/lib/python2.7/site-packages/elasticsearch/client/__init__.py", line 636, in search
apise_1            |     doc_type, '_search'), params=params, body=body)
apise_1            |   File "/usr/local/lib/python2.7/site-packages/elasticsearch/transport.py", line 314, in perform_request
apise_1            |     status, headers_response, data = connection.perform_request(method, url, params, body, headers=headers, ignore=ignore, timeout=timeout)
apise_1            |   File "/usr/local/lib/python2.7/site-packages/elasticsearch/connection/http_urllib3.py", line 163, in perform_request
apise_1            |     self._raise_error(response.status, raw_data)
apise_1            |   File "/usr/local/lib/python2.7/site-packages/elasticsearch/connection/base.py", line 125, in _raise_error
apise_1            |     raise HTTP_EXCEPTIONS.get(status_code, TransportError)(status_code, error_message, additional_info)
apise_1            | RequestError: TransportError(400, u'search_phase_execution_exception', u'failed to create query: {\n  "terms" : {\n    "bigquery-public-data.human_genome_variants.1000_genomes_sample_info.In_Final_Phase_Variant_Calling" : [\n      "1"\n    ],\n    "boost" : 1.0\n  }\n}')
```

Confirmed this fixes the bug.