### PR TITLE
Change 1000 Genomes enable_field_search back to false

### DIFF
--- a/dataset_config/1000_genomes/ui.json
+++ b/dataset_config/1000_genomes/ui.json
@@ -69,5 +69,5 @@
         "samples.bryancrampton-testing.data_explorer.1000_genomes_sample_info.Main_project_LC_platform"
     }
   ],
-  "enable_field_search": "true"
+  "enable_field_search": false
 }


### PR DESCRIPTION
I'd rather not enable by default, until feature is usable.