### PR TITLE
Support adding facets with field search

### DIFF
--- a/api/data_explorer/controllers/facets_controller.py
+++ b/api/data_explorer/controllers/facets_controller.py
@@ -1,13 +1,16 @@
 import pprint
+import urllib
+
+from collections import OrderedDict
+from elasticsearch import Elasticsearch
+from elasticsearch_dsl import HistogramFacet
+from flask import current_app
 
 from data_explorer.models.facet import Facet
 from data_explorer.models.facet_value import FacetValue
 from data_explorer.models.facets_response import FacetsResponse
+from data_explorer.util import elasticsearch_util
 from data_explorer.util.dataset_faceted_search import DatasetFacetedSearch
-
-from elasticsearch_dsl import HistogramFacet
-from flask import current_app
-import urllib
 
 
 def _is_histogram_facet(facet):
@@ -28,25 +31,58 @@ def _get_bucket_interval(facet):
         return _get_bucket_interval(facet.nested_facet)
 
 
-def facets_get(filter=None):  # noqa: E501
+def _process_extra_facets(extra_facets):
+    es = Elasticsearch(current_app.config['ELASTICSEARCH_URL'])
+
+    es_facets = OrderedDict()
+    ui_facets = OrderedDict()
+
+    if not extra_facets:
+        return es_facets, ui_facets
+
+    for elasticsearch_field_name in extra_facets:
+        if not elasticsearch_field_name:
+            continue
+
+        arr = elasticsearch_field_name.split('.')
+        ui_facet_name = arr[-1]
+        field_type = elasticsearch_util.get_field_type(
+            es, elasticsearch_field_name)
+        ui_facets[ui_facet_name] = {
+            'elasticsearch_field_name': elasticsearch_field_name,
+            'type': field_type
+        }
+        # TODO(malathir): Figure out how to get description of the field.
+        es_facets[ui_facet_name] = elasticsearch_util.get_elasticsearch_facet(
+            es, elasticsearch_field_name, field_type)
+
+    return es_facets, ui_facets
+
+
+def facets_get(filter=None, extraFacets=None):  # noqa: E501
     """facets_get
-
     Returns facets. # noqa: E501
-
     :param filter: filter represents selected facet values. Elasticsearch query will be run only over selected facet values. filter is an array of strings, where each string has the format \&quot;facetName&#x3D;facetValue\&quot;. Example url /facets?filter&#x3D;Gender&#x3D;female,Region&#x3D;northwest,Region&#x3D;southwest
     :type filter: List[str]
-
+    :param extraFacets: extra_facets represents the additional facets selected by the user from the UI.
+    :type extraFacets: List[str]
     :rtype: FacetsResponse
     """
-    search = DatasetFacetedSearch(deserialize(filter))
+    extra_es_facets, extra_ui_facets = _process_extra_facets(extraFacets)
+    combined_es_facets = OrderedDict(extra_es_facets.items() + current_app.
+                                     config['ELASTICSEARCH_FACETS'].items())
+    combined_ui_facets = OrderedDict(extra_ui_facets.items() +
+                                     current_app.config['UI_FACETS'].items())
+    search = DatasetFacetedSearch(
+        deserialize(filter, combined_es_facets), combined_es_facets)
     es_response = search.execute()
     es_response_facets = es_response.facets.to_dict()
     # Uncomment to print facets
     # current_app.logger.info(pprint.pformat(es_response_facets))
     facets = []
-    for name, field in current_app.config['UI_FACETS'].iteritems():
+    for name, field in combined_ui_facets.iteritems():
         description = field.get('description')
-        es_facet = current_app.config['ELASTICSEARCH_FACETS'][name]
+        es_facet = combined_es_facets[name]
         values = []
         for value_name, count, _ in es_response_facets[name]:
             if _is_histogram_facet(es_facet):
@@ -68,22 +104,21 @@ def facets_get(filter=None):  # noqa: E501
         facets=facets, count=es_response._faceted_search.count())
 
 
-def deserialize(filter_arr):
+def deserialize(filter_arr, es_facets):
     """
     :param filter_arr: an array of strings with format "facet_name=facet_value".
-    A facet_name may be repeated if multiple filters are desired.
+     A facet_name may be repeated if multiple filters are desired.
+    :param es_facets: a map from UI facet name to Elasticsearch facet object
     :return: A dict of facet_name:[facet_value] mappings.
     """
     if not filter_arr or filter_arr == [""]:
         return {}
     parsed_filter = {}
-    # filter_str looks like "Gender=male"
     for facet_filter in filter_arr:
         filter_str = urllib.unquote(facet_filter).decode('utf8')
         key_val = filter_str.split('=')
         name = key_val[0]
-
-        es_facet = current_app.config['ELASTICSEARCH_FACETS'][name]
+        es_facet = es_facets[name]
         if _is_histogram_facet(es_facet):
             value = _range_to_number(key_val[1])
         else:

--- a/api/data_explorer/util/dataset_faceted_search.py
+++ b/api/data_explorer/util/dataset_faceted_search.py
@@ -1,5 +1,6 @@
 """Subclass of FacetedSearch for Data Explorer datasets."""
 
+from collections import OrderedDict
 from flask import current_app
 
 from elasticsearch import Elasticsearch
@@ -9,14 +10,15 @@ from elasticsearch_dsl import FacetedSearch
 class DatasetFacetedSearch(FacetedSearch):
     """Subclass of FacetedSearch for Datasets."""
 
-    def __init__(self, filters={}):
+    def __init__(self, filters={}, es_facets={}):
         """
         :param filters: a dictionary of facet_name:[object] values to filter
         the query on.
         Ex: {'Region':['southeast', 'northwest'], 'Gender':['male']}.
+        :param es_facets: a dict of facets to perform faceted search on.
         """
         self.index = current_app.config['INDEX_NAME']
-        self.facets = current_app.config['ELASTICSEARCH_FACETS']
+        self.facets = es_facets
         self.using = Elasticsearch(current_app.config['ELASTICSEARCH_URL'])
         # Now that using is set, create _s.
         super(DatasetFacetedSearch, self).__init__(None, filters)

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -8113,7 +8113,6 @@
               "version": "2.2.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.1",
                 "yallist": "^3.0.0"
@@ -8132,7 +8131,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -8226,7 +8224,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -8312,8 +8309,7 @@
             "safe-buffer": {
               "version": "5.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -8413,14 +8409,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -9588,8 +9582,7 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
@@ -9600,8 +9593,7 @@
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -9718,8 +9710,7 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -9731,7 +9722,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -9761,7 +9751,6 @@
               "version": "2.2.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.1",
                 "yallist": "^3.0.0"
@@ -9780,7 +9769,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -9874,7 +9862,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -9996,7 +9983,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",

--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -55,10 +55,10 @@ class App extends Component {
       } else {
         this.setState({
           fields: data.fields.map(field => {
-           return {
-               label: field.name,
-               value: field.elasticsearch_name
-           };
+            return {
+              label: field.name,
+              value: field.elasticsearch_name
+            };
           })
         });
       }
@@ -178,7 +178,8 @@ class App extends Component {
     let filterArray = this.filterMapToArray(this.filterMap);
     this.setState({ filter: filterArray });
 
-    this.facetsApi.facetsGet({
+    this.facetsApi.facetsGet(
+      {
         filter: filterArray,
         extraFacets: this.state.extraFacetsOptions.map(option => option.value)
       },

--- a/ui/src/components/FieldSearch.js
+++ b/ui/src/components/FieldSearch.js
@@ -3,20 +3,16 @@ import Select from "react-select";
 
 class FieldSearch extends React.Component {
   constructor(props) {
-    const fields = props.fields;
     super(props);
-    this.handleChange = props.handleChange;
-    this.state = {
-      fields: fields
-    };
   }
 
   render() {
     return (
       <Select
         isMulti="true"
-        onChange={this.handleChange}
-        options={this.state.fields}
+        onChange={this.props.handleChange}
+        options={this.props.fields}
+        value={this.props.extraFacetsOptions}
       />
     );
   }

--- a/ui/tests/unit/__tests__/App.test.js
+++ b/ui/tests/unit/__tests__/App.test.js
@@ -39,15 +39,18 @@ test("Stringifies queries when calling the API to update Facets", () => {
     tree.instance().facetsCallback
   );
   expect(mockFacetsGet).toHaveBeenCalledWith(
-    { filter: ["Facet 1=FacetValue 1"] },
+    { filter: ["Facet 1=FacetValue 1"], extraFacets: [] },
     tree.instance().facetsCallback
   );
   expect(mockFacetsGet).toHaveBeenCalledWith(
-    { filter: ["Facet 1=FacetValue 1", "Facet 1=FacetValue 2"] },
+    {
+      filter: ["Facet 1=FacetValue 1", "Facet 1=FacetValue 2"],
+      extraFacets: []
+    },
     tree.instance().facetsCallback
   );
   expect(mockFacetsGet).toHaveBeenCalledWith(
-    { filter: ["Facet 1=FacetValue 2"] },
+    { filter: ["Facet 1=FacetValue 2"], extraFacets: [] },
     tree.instance().facetsCallback
   );
 });


### PR DESCRIPTION
Malathi, can you please manually test? Thanks.

Differences from your branch:

I changed the react-select label to only be "field name" instead of "field name - description". With the latter, deleting a chip didn't work. this.filterMap key was "Avuncular", but label was "Avuncular - sample ids for any avuncular relationships". (This worked for Malathi because her cached index didn't have field descriptions.)


I pass `extraFacetsOptions` into FieldSearch/Select components as a prop.

In React, state is something a component has to actively manage. Prop is a read-only property that's passed in from parent.

Old PR: Both App and React select components had extraFacetsOptions as state. This means our code has to make sure they're in sync. I'm guessing this would have led to subtle bugs in the future. There may even have been subtle bugs with the PR.

This PR: App component has extraFacetsOption as state. App component passes extraFacetsOptions to React select component via prop. So our code only has to worry about maintaining one extraFacetsOptions.


extraFacetsEsFieldNames is not stored in state, since it can be computed from extraFacetsOptions. In React, [state should be minimal](https://reactjs.org/docs/thinking-in-react.html#step-3-identify-the-minimal-but-complete-representation-of-ui-state). Including both in state might not seem bad, but in practice, it leads to subtle bugs over time, because there will be bugs where the two variables aren't in sync. That's why React has this guideline.