### PR TITLE
Stop checking for export bucket in __main__.py

### DIFF
--- a/api/data_explorer/__main__.py
+++ b/api/data_explorer/__main__.py
@@ -14,7 +14,6 @@ from elasticsearch import Elasticsearch
 from elasticsearch.client.cat import CatClient
 from elasticsearch.exceptions import ConnectionError
 from elasticsearch.exceptions import TransportError
-from google.cloud import storage
 
 from .encoder import JSONEncoder
 from data_explorer.util import elasticsearch_util
@@ -247,12 +246,6 @@ def _process_export_url():
         app.app.config['DEPLOY_PROJECT_ID'] = project_id
 
     app.app.config['EXPORT_URL_GCS_BUCKET'] = project_id + '-export'
-    client = storage.Client(project=project_id)
-    if not client.lookup_bucket(app.app.config['EXPORT_URL_GCS_BUCKET']):
-        app.app.logger.warning(
-            'Bucket %s not found. Export to Saturn feature will not work. '
-            'See https://github.com/DataBiosphere/data-explorer#one-time-setup-for-export-to-saturn-feature-for-export-to-saturn-feature'
-            % app.app.config['EXPORT_URL_GCS_BUCKET'])
 
 
 # On server startup, read and process config files, and populate


### PR DESCRIPTION
If the export bucket doesn't exist, my intention was to print a warning and allow API server to continue.

If deploy.json project_id is "BLAH", then checking for bucket will fail the API server, because "BLAH-export"  isn't a valid bucket name.

```
apise_1          | [2018-10-02 22:59:15 +0000] [10] [ERROR] Exception in worker process
apise_1          | Traceback (most recent call last):
apise_1          |   File "/usr/local/lib/python2.7/site-packages/gunicorn/arbiter.py", line 578, in spawn_worker
apise_1          |     worker.init_process()
apise_1          |   File "/usr/local/lib/python2.7/site-packages/gunicorn/workers/base.py", line 126, in init_process
apise_1          |     self.load_wsgi()
apise_1          |   File "/usr/local/lib/python2.7/site-packages/gunicorn/workers/base.py", line 135, in load_wsgi
apise_1          |     self.wsgi = self.app.wsgi()
apise_1          |   File "/usr/local/lib/python2.7/site-packages/gunicorn/app/base.py", line 67, in wsgi
apise_1          |     self.callable = self.load()
apise_1          |   File "/usr/local/lib/python2.7/site-packages/gunicorn/app/wsgiapp.py", line 65, in load
apise_1          |     return self.load_wsgiapp()
apise_1          |   File "/usr/local/lib/python2.7/site-packages/gunicorn/app/wsgiapp.py", line 52, in load_wsgiapp
apise_1          |     return util.import_app(self.app_uri)
apise_1          |   File "/usr/local/lib/python2.7/site-packages/gunicorn/util.py", line 352, in import_app
apise_1          |     __import__(module)
apise_1          |   File "/app/data_explorer/__main__.py", line 290, in <module>
apise_1          |     init()
apise_1          |   File "/app/data_explorer/__main__.py", line 283, in init
apise_1          |     _process_export_url()
apise_1          |   File "/app/data_explorer/__main__.py", line 265, in _process_export_url
apise_1          |     if not client.lookup_bucket(app.app.config['EXPORT_URL_GCS_BUCKET']):
apise_1          |   File "/usr/local/lib/python2.7/site-packages/google/cloud/storage/client.py", line 227, in lookup_bucket
apise_1          |     return self.get_bucket(bucket_name)
apise_1          |   File "/usr/local/lib/python2.7/site-packages/google/cloud/storage/client.py", line 207, in get_bucket
apise_1          |     bucket.reload(client=self)
apise_1          |   File "/usr/local/lib/python2.7/site-packages/google/cloud/storage/_helpers.py", line 108, in reload
apise_1          |     _target_object=self)
apise_1          |   File "/usr/local/lib/python2.7/site-packages/google/cloud/_http.py", line 293, in api_request
apise_1          |     raise exceptions.from_http_response(response)
apise_1          | BadRequest: 400 GET https://www.googleapis.com/storage/v1/b/BLAH-export?projection=noAcl: Invalid bucket name: 'BLAH-export'
apise_1          | [2018-10-02 22:59:15 +0000] [10] [INFO] Worker exiting (pid: 10)
apise_1          | Index name: encode_test
apise_1          | [2018-10-02 22:59:15 +0000] [1] [INFO] Shutting down: Master
apise_1          | [2018-10-02 22:59:15 +0000] [1] [INFO] Reason: Worker failed to boot.
```