### PR TITLE
Make e2e tests faster

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,10 @@ curl -XDELETE localhost:9200/_all
 docker-compose up --build
 cd ui && npm run test:e2e
 ```
+Troubleshooting tips for end-to-end tests:
+- [Uncomment headless](https://github.com/DataBiosphere/data-explorer/blob/master/ui/jest-puppeteer.config.js)
+to see the browser during test run.
+- Run a single test: `npm run test:e2e -- -t "test name"`
 
 ### Formatting
 

--- a/api/data_explorer/__main__.py
+++ b/api/data_explorer/__main__.py
@@ -76,7 +76,7 @@ def init_elasticsearch():
                                 (time.time() - start))
             # For local deployment, load_test_data will delete and recreate
             # 1000 Genomes index. Wait for load_test_data to finish.
-            time.sleep(5)
+            time.sleep(10)
             break
         except ConnectionError:
             app.app.logger.info('Elasticsearch not up yet, will try again.')

--- a/ui/jest-puppeteer.config.js
+++ b/ui/jest-puppeteer.config.js
@@ -3,8 +3,8 @@ module.exports = {
     //    Uncomment to see console.log output.
     //    dumpio: true,
     //    Uncomment to see browser.
-    //    headless: false,
+        headless: false,
     //    Uncomment to slow down execution. Unit is ms.
-    //    slowMo: 100,
+        slowMo: 200,
   }
 };

--- a/ui/jest-puppeteer.config.js
+++ b/ui/jest-puppeteer.config.js
@@ -3,8 +3,8 @@ module.exports = {
     //    Uncomment to see console.log output.
     //    dumpio: true,
     //    Uncomment to see browser.
-        headless: false,
+//        headless: false,
     //    Uncomment to slow down execution. Unit is ms.
-        slowMo: 200,
+//        slowMo: 200,
   }
 };

--- a/ui/tests/e2e/test.js
+++ b/ui/tests/e2e/test.js
@@ -1,18 +1,12 @@
 const JEST_TIMEOUT_MS = 60 * 1000;
 
-class MyCustomReporter {
-  constructor(globalConfig, options) {
-    this._globalConfig = globalConfig;
-    this._options = options;
-  }
+// Print test name at the beginning of each test
+jasmine.getEnv().addReporter({
+    specStarted: function(result) {
+        console.log(result.fullName);
+    }
+});
 
-  onTestStart(contexts, results) {
-    console.log('Custom reporter output:');
-    console.log('GlobalConfig: ', this._globalConfig);
-    console.log('Options: ', this._options);
-  }
-}
-module.exports = MyCustomReporter;
 describe("End-to-end", () => {
 
   beforeAll(async () => {
@@ -22,7 +16,6 @@ describe("End-to-end", () => {
   });
 
   beforeEach(async () => {
-    
     await page.goto("http://localhost:4400");
     await page.waitForSelector("span.datasetName");
   });
@@ -32,12 +25,11 @@ describe("End-to-end", () => {
     await assertHeaderTotalCount("3714");
   });
 
-  test("Gender facet", async () => {
-    await assertFacet("Gender", "3500", "female", "1760");
-  });
+  test("Participant facet", async () => {
+    // Assert facet rendered correctly
+    await assertFacet("Super Population", "3500", "African", "1018");
 
-  test("Click on participant facet", async () => {
-    // Click on a participant facet.
+    // Click on facet value
     let facetValueRow = await getFacetValueRow("Super Population", "African");
     await facetValueRow.click("input");
     // Wait for data to be returned from backend.
@@ -49,7 +41,6 @@ describe("End-to-end", () => {
     // Assert page updated correctly.
     await assertHeaderTotalCount("1018");
     await assertFacet("Gender", "1018", "male", "518");
-    await assertFacet("Total Exome Sequence", "707", "0B-10B", "435");
 
     // Make sure non-selected facet values are gray.
     facetValueRow = await getFacetValueRow("Super Population", "European");
@@ -57,8 +48,11 @@ describe("End-to-end", () => {
     expect(grayDiv).toBeTruthy();
   });
 
-  test("Click on sample facet", async () => {
-    // Click on a sample facet.
+  test("Sample facet", async () => {
+    // Assert facet rendered correctly
+    await assertFacet("Total Low Coverage Sequence", "2688", "0B-10B", "10");
+
+    // Click on facet value
     let facetValueRow = await getFacetValueRow("Total Low Coverage Sequence", "10B-20B");
     await facetValueRow.click("input");
     // Wait for data to be returned from backend.
@@ -69,8 +63,7 @@ describe("End-to-end", () => {
 
     // Assert page updated correctly.
     await assertHeaderTotalCount("1122");
-    await assertFacet("Super Population", "1122", "African", "281");
-    await assertFacet("Total Exome Sequence", "1108", "0B-10B", "682");
+    await assertFacet("Gender", "1122", "female", "569");
 
     // Make sure non-selected facet values are gray.
     facetValueRow = await getFacetValueRow("Total Low Coverage Sequence", "0B-10B");
@@ -79,7 +72,10 @@ describe("End-to-end", () => {
   });
 
   test("Samples Overview facet", async () => {
-    // Click on Samples Overview facet.
+    // Skip asserting facet rendered correctly, because this facet doesn't have
+    // totalFacetValueCount span.
+
+    // Click on facet value
     let facetValueRow = await getFacetValueRow("Samples Overview", "Has WGS Low Coverage BAM");
     await facetValueRow.click("input");
     // Wait for data to be returned from backend.
@@ -91,7 +87,6 @@ describe("End-to-end", () => {
     // Assert page updated correctly.
     await assertHeaderTotalCount("2535");
     await assertFacet("Gender", "2535", "female", "1291");
-    await assertFacet("Total Exome Sequence", "2535", "0B-10B", "1429");
 
     // Make sure non-selected facet values are gray.
     facetValueRow = await getFacetValueRow("Samples Overview", "Has Exome BAM");
@@ -99,22 +94,11 @@ describe("End-to-end", () => {
     expect(grayDiv).toBeTruthy();
 
     // Test exporting to saturn.
-    await page.click("button[title='Send to Saturn']");
-    await page.waitForSelector("#name");
-    await page.type("#name", "c");
-    await Promise.all([
-      page.click("#save"),
-      page.waitForNavigation()
-    ]);
-    expect(await page.url()).toBe("https://bvdp-saturn-prod.appspot.com/");
+    await exportToSaturn_selectedCohort();
   });
 
   test("Export to Saturn - no selected cohort", async () => {
-    await Promise.all([
-      page.click("button[title='Send to Saturn']"),
-      page.waitForNavigation()
-    ]);
-    expect(await page.url()).toBe("https://bvdp-saturn-prod.appspot.com/");
+    await exportToSaturn_noSelectedCohort();
   });
 
   test("Export to Saturn - selected cohort", async () => {
@@ -126,15 +110,8 @@ describe("End-to-end", () => {
     await page.waitForXPath(
       "//div[contains(@class, 'totalCountText') and text() = '1018']"
     );
-    await page.click("button[title='Send to Saturn']");
-    await page.waitForSelector("#name");
 
-    await page.type("#name", "c");
-    await Promise.all([
-      page.click("#save"),
-      page.waitForNavigation()
-    ]);
-    expect(await page.url()).toBe("https://bvdp-saturn-prod.appspot.com/");
+    await exportToSaturn_selectedCohort();
   });
 
   async function waitForElasticsearchIndex() {
@@ -205,7 +182,7 @@ describe("End-to-end", () => {
       (facetCard, valueName) => {
         let divs = facetCard.querySelectorAll("label");
         for (let div of divs) {
-          if (div.innerText.match(valueName)) return div;
+          if (div.innerText.includes(valueName)) return div;
         }
         return null;
       },
@@ -224,11 +201,31 @@ describe("End-to-end", () => {
       const divs = document.querySelectorAll("div.facetCard");
       for (const div of divs) {
         const name = div.querySelector("span").innerText;
-        if (name.match(innerFacetName)) return div;
+        if (name.includes(innerFacetName)) return div;
       }
       return null;
     }, facetName)).asElement();
     expect(facetCard).toBeTruthy();
     return facetCard;
+  }
+
+  async function exportToSaturn_noSelectedCohort() {
+    await page.click("button[title='Send to Saturn']");
+    // Jest documentation says to use waitForNavigation():
+    // https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pageclickselector-options
+    // Here we use waitForRequest() instead. waitForRequest() is slightly
+    // faster because it doesn't wait for the Saturn page to finish (or start?)
+    // loading.
+    await page.waitForRequest("https://bvdp-saturn-prod.appspot.com/");
+  }
+
+  async function exportToSaturn_selectedCohort() {
+    await page.click("button[title='Send to Saturn']");
+    // Wait for cohort name dialog
+    await page.waitForSelector("#name");
+
+    await page.type("#name", "c");
+    await page.click("#save");
+    await page.waitForRequest("https://bvdp-saturn-prod.appspot.com/");
   }
 });

--- a/ui/tests/e2e/test.js
+++ b/ui/tests/e2e/test.js
@@ -1,10 +1,28 @@
 const JEST_TIMEOUT_MS = 60 * 1000;
 
+class MyCustomReporter {
+  constructor(globalConfig, options) {
+    this._globalConfig = globalConfig;
+    this._options = options;
+  }
+
+  onTestStart(contexts, results) {
+    console.log('Custom reporter output:');
+    console.log('GlobalConfig: ', this._globalConfig);
+    console.log('Options: ', this._options);
+  }
+}
+module.exports = MyCustomReporter;
 describe("End-to-end", () => {
-  beforeEach(async () => {
+
+  beforeAll(async () => {
     // It can take a while for servers to start up
     jest.setTimeout(JEST_TIMEOUT_MS);
     await waitForElasticsearchIndex();
+  });
+
+  beforeEach(async () => {
+    
     await page.goto("http://localhost:4400");
     await page.waitForSelector("span.datasetName");
   });
@@ -83,15 +101,18 @@ describe("End-to-end", () => {
     // Test exporting to saturn.
     await page.click("button[title='Send to Saturn']");
     await page.waitForSelector("#name");
-    await page.type("#name", "samples-cohort");
-    await Promise.all([page.click("#save"), page.waitFor(15000)]);
+    await page.type("#name", "c");
+    await Promise.all([
+      page.click("#save"),
+      page.waitForNavigation()
+    ]);
     expect(await page.url()).toBe("https://bvdp-saturn-prod.appspot.com/");
   });
 
   test("Export to Saturn - no selected cohort", async () => {
     await Promise.all([
       page.click("button[title='Send to Saturn']"),
-      page.waitFor(15000)
+      page.waitForNavigation()
     ]);
     expect(await page.url()).toBe("https://bvdp-saturn-prod.appspot.com/");
   });
@@ -108,8 +129,11 @@ describe("End-to-end", () => {
     await page.click("button[title='Send to Saturn']");
     await page.waitForSelector("#name");
 
-    await page.type("#name", "test-cohort");
-    await Promise.all([page.click("#save"), page.waitFor(15000)]);
+    await page.type("#name", "c");
+    await Promise.all([
+      page.click("#save"),
+      page.waitForNavigation()
+    ]);
     expect(await page.url()).toBe("https://bvdp-saturn-prod.appspot.com/");
   });
 


### PR DESCRIPTION
Before this PR: 51s
After this PR: 6s

This biggest cause of slowness was this:
```
    await Promise.all([
      page.click("button[title='Send to Saturn']"),
      page.waitFor(15000)
```
This would wait for 15s after clicking button, regardless of how long the redirect to Saturn took.

Other changes:
- Console.log test name at beginning of each test
- Made cohort name short so test is faster in slowMo mode
- Change `match()` to `includes()`. matches takes in a regex. In Javascript, `"Total Low Coverage Sequence (samples)".match("Total Low Coverage Sequence (samples)")` is null. `"Total Low Coverage Sequence (samples)".inclues("Total Low Coverage Sequence (samples)")` is true. Currently our tests are not affected because they have just `"Total Low Coverage Sequence (samples)"`, but this gives us the free to add the `"(samples)"` if we want.

The biggest bottleneck now is /exportUrl. I have an idea to make that faster -- API server can start writing entity GCS file when user clicks Export button, instead of when user clicks Save in cohort name dialog.