### PR TITLE
Run prettier on FacetCard.js

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,12 +1,16 @@
 # git secrets
-* Install git secrets if you haven't done so already.
-	* Mac
-	  `brew install git-secrets`
-	* Linux
-	  git clone https://github.com/awslabs/git-secrets.git
-	  sudo make install
-	  
-* Copy the files in this directory to `.git/hooks`. If you have previously run
-`npm install` in `ui/` directory, `.git/hooks/pre-commit` will contain husky
-section. Be sure to put git secrets section before husky section; otherwise git
-secrets section won't run.
+
+Note - husky pre-commit doesn't work with git-secrets. We recommend running
+husky on pre-commit and not git-secrets. When [this issue](https://github.com/typicode/husky/issues/171)
+is fixed, perhaps it will be easier to do both.
+
+- Install git secrets if you haven't done so already.
+  _ Mac
+  `brew install git-secrets`
+  _ Linux
+  git clone https://github.com/awslabs/git-secrets.git
+  sudo make install
+- Copy the files in this directory to `.git/hooks`. If you have previously run
+  `npm install` in `ui/` directory, `.git/hooks/pre-commit` will contain husky
+  section. Be sure to put git secrets section before husky section; otherwise git
+  secrets section won't run.

--- a/ui/src/components/facets/FacetCard.js
+++ b/ui/src/components/facets/FacetCard.js
@@ -10,7 +10,7 @@ import "components/facets/FacetCard.css";
 
 const styles = theme => ({
   root: {
-    // Disable gray background on ListItem hover. It's not possible to inlinesdfsdf
+    // Disable gray background on ListItem hover. It's not possible to inline
     // hover CSS
     // (https://stackoverflow.com/questions/1033156/how-to-write-ahover-in-inline-css)
     // so we have to do it this way.

--- a/ui/src/components/facets/FacetCard.js
+++ b/ui/src/components/facets/FacetCard.js
@@ -1,22 +1,22 @@
 import React, { Component } from "react";
-import { withStyles } from '@material-ui/core/styles';
-import Checkbox from '@material-ui/core/Checkbox';
-import List from '@material-ui/core/List';
-import ListItem from '@material-ui/core/ListItem';
-import ListItemText from '@material-ui/core/ListItemText';
+import { withStyles } from "@material-ui/core/styles";
+import Checkbox from "@material-ui/core/Checkbox";
+import List from "@material-ui/core/List";
+import ListItem from "@material-ui/core/ListItem";
+import ListItemText from "@material-ui/core/ListItemText";
 
-import * as Style from "libs/style"
+import * as Style from "libs/style";
 import "components/facets/FacetCard.css";
 
 const styles = theme => ({
   root: {
-    // Disable gray background on ListItem hover. It's not possible to inline
+    // Disable gray background on ListItem hover. It's not possible to inlinesdfsdf
     // hover CSS
     // (https://stackoverflow.com/questions/1033156/how-to-write-ahover-in-inline-css)
     // so we have to do it this way.
-    '&:hover': {
-      backgroundColor: 'unset',
-    },
+    "&:hover": {
+      backgroundColor: "unset"
+    }
   }
 });
 
@@ -58,37 +58,37 @@ class FacetCard extends Component {
         button
         dense
         disableRipple
-        onClick={(e) => this.onClick(facetValue.name)}
+        onClick={e => this.onClick(facetValue.name)}
       >
         <Checkbox
-          style={{ width:'24px', height:'24px' }}
+          style={{ width: "24px", height: "24px" }}
           checked={this.state.selectedValues.includes(facetValue.name)}
         />
-        <ListItemText primary={
-          <div className={this.isDimmed(facetValue) ? " grayText" : ""}>
-            <div className="facetValueName">{facetValue.name}</div>
-            <div className="facetValueCount">{facetValue.count}</div>
-          </div>
-        } />
+        <ListItemText
+          primary={
+            <div className={this.isDimmed(facetValue) ? " grayText" : ""}>
+              <div className="facetValueName">{facetValue.name}</div>
+              <div className="facetValueCount">{facetValue.count}</div>
+            </div>
+          }
+        />
       </ListItem>
     ));
     const totalFacetValueCount = (
-      <span className="totalFacetValueCount">
-        {this.totalFacetValueCount}
-      </span>
+      <span className="totalFacetValueCount">{this.totalFacetValueCount}</span>
     );
     return (
-      <div className="facetCard" style={ Style.elements.card }>
-          <div>
-            <span>{this.props.facet.name}</span>
-            {this.props.facet.name != "Samples Overview"
-              ? totalFacetValueCount
-              : null}
-          </div>
-          <span className="facetDescription">
-            {this.props.facet.description}
-          </span>
-        <List dense disablePadding>{facetValues}</List>
+      <div className="facetCard" style={Style.elements.card}>
+        <div>
+          <span>{this.props.facet.name}</span>
+          {this.props.facet.name != "Samples Overview"
+            ? totalFacetValueCount
+            : null}
+        </div>
+        <span className="facetDescription">{this.props.facet.description}</span>
+        <List dense disablePadding>
+          {facetValues}
+        </List>
       </div>
     );
   }
@@ -96,7 +96,7 @@ class FacetCard extends Component {
   isDimmed(facetValue) {
     return (
       this.state.selectedValues.length > 0 &&
-      !(this.state.selectedValues.includes(facetValue.name))
+      !this.state.selectedValues.includes(facetValue.name)
     );
   }
 
@@ -137,9 +137,12 @@ class FacetCard extends Component {
     }
 
     this.setState({ selectedValues: newValues });
-    this.props.updateFacets(this.props.facet.es_field_name, facetValue, isSelected);
+    this.props.updateFacets(
+      this.props.facet.es_field_name,
+      facetValue,
+      isSelected
+    );
   }
-
 }
 
 export default withStyles(styles)(FacetCard);


### PR DESCRIPTION
Turns out I had husky pre-commit disabled. I reenabled it (by rerunning `npm install husky`).

Ideally CircleCi would check for prettier formatting, just like it checks Python.

prettier/pretty-quick is pretty confusing; I can't figure out the command to reformat all .js/.css files. So this PR contains just one file.