### PR TITLE
Fix undefined in chip

### DIFF
--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -95,7 +95,7 @@ class App extends Component {
   }
 
   render() {
-    if (this.state.facets == null || this.state.datasetName === "") {
+    if (this.state.facets.size == 0 || this.state.datasetName === "") {
       // Server has not yet responded or returned an error
       return <div />;
     } else {


### PR DESCRIPTION
I see this problem on deployed instances, not local instance.

To repro problem:
- https://test-data-explorer.appspot.com/
- Click on African
- Chip shows "undefined=African" instead of "Super Population=African".

This line in App.js makes sure the facets and dataset calls have finished:
```
    if (this.state.facets == null || this.state.datasetName === "") {
```

Before #213, this.state.facets was initialized to null, so `this.state.facets == null` made sense.

After #213, this.state.facets is initialized to `new Map()`, so the check needs to be updated.