### PR TITLE
Fix filtering with negative numbers

### DIFF
--- a/api/data_explorer/test/test_elasticsearch_util.py
+++ b/api/data_explorer/test/test_elasticsearch_util.py
@@ -16,3 +16,5 @@ def test_range_to_number():
     _inner('1', 1)
     _inner('10-20', 10)
     _inner('10M-20M', 10000000)
+    _inner('-20--10', -20)
+    _inner('-10-0', -10)

--- a/api/data_explorer/util/elasticsearch_util.py
+++ b/api/data_explorer/util/elasticsearch_util.py
@@ -84,7 +84,12 @@ def range_to_number(interval_str):
     if not '-' in interval_str:
         return int(interval_str)
 
-    number = interval_str.split('-')[0]
+    # If first character is -, X is a negative number
+    if interval_str.startswith('-'):
+        number = '-' + interval_str.split('-')[1]
+    else:
+        number = interval_str.split('-')[0]
+
     number = number.replace('M', '000000')
     number = number.replace('B', '000000000')
     if '.' in number:

--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -38,10 +38,10 @@ class App extends Component {
     super(props);
     this.state = {
       datasetName: "",
-      // A dict from es_field_name to facet data returned from API server /facets call.
+      // Map from es_field_name to facet data returned from API server /facets call.
       facets: new Map(),
       totalCount: null,
-      // Map from facet name to a list of selected facet values.
+      // Map from es_field_name to a list of selected facet values.
       selectedFacetValues: new Map(),
       // Search results shown in the search drop-down.
       // This is an array of dicts, where each dict has

--- a/ui/src/components/Search.js
+++ b/ui/src/components/Search.js
@@ -12,16 +12,9 @@ const customStyles = {
 class Search extends React.Component {
   constructor(props) {
     super(props);
-    this.facetNameMap = this.getFacetNameMap(this.props.facets);
-    this.chipsFromFilter = this.chipsFromFilter.bind(this);
-  }
-
-  getFacetNameMap(facets) {
-    var facetNameMap = new Map();
-    facets.forEach(function(facet) {
-      facetNameMap.set(facet.es_field_name, facet.name);
-    });
-    return facetNameMap;
+    this.chipsFromSelectedFacetValues = this.chipsFromSelectedFacetValues.bind(
+      this
+    );
   }
 
   // renderOption is used to render 1) chip, 2) row in drop-down.
@@ -63,10 +56,10 @@ class Search extends React.Component {
     }
   };
 
-  chipsFromFilter(filterMap) {
+  chipsFromSelectedFacetValues(selectedFacetValues) {
     let chips = [];
-    filterMap.forEach((values, key) => {
-      let facetName = this.facetNameMap.get(key);
+    selectedFacetValues.forEach((values, key) => {
+      let facetName = this.props.facets.get(key).name;
       if (values.length > 0) {
         for (let value of values) {
           chips.push({
@@ -90,7 +83,9 @@ class Search extends React.Component {
         options={this.props.searchResults}
         getOptionLabel={this.renderOption}
         getOptionValue={this.renderValue}
-        value={this.chipsFromFilter(this.props.selectedFacetValues)}
+        value={this.chipsFromSelectedFacetValues(
+          this.props.selectedFacetValues
+        )}
         styles={customStyles}
       />
     );


### PR DESCRIPTION
I am deploying the fix to https://baseline-baseline-explorer.appspot.com/, so these bugs can only be reproed locally.

Bug 1 - Filtering broken with negative numbers
- In Baseline Baseline data explorer, add facet predicted_actual_age_diff
- Click "-20--10".
- Facets don't update as expected

Bug 2 - Chips don't show correctly for facets added by search box
- Add a facet with search box
- Click a value in newly added facet
- Chip shows "undefined=value"

A future PR will add e2e test for Bug 2.