### PR TITLE
Remove align=start from FacetCard

### DIFF
--- a/ui/src/components/facets/FacetCard.js
+++ b/ui/src/components/facets/FacetCard.js
@@ -40,8 +40,6 @@ const styles = {
     display: "grid",
     gridTemplateColumns: "24px auto",
     justifyContent: "stretch",
-    // If facet value is two lines, align checkbox to the top
-    alignItems: "start",
     padding: "0",
     // Disable gray background on ListItem hover.
     "&:hover": {


### PR DESCRIPTION
With align=start:
![with_align_start](https://user-images.githubusercontent.com/10929390/49259175-22b6bc80-f3ed-11e8-8bab-52682a7ffa5f.png)

Without align=start:
![without_align_start](https://user-images.githubusercontent.com/10929390/49259174-20ecf900-f3ed-11e8-9f88-4900696c0544.png)

I added `align=start` to make the checkbox look better when the facet value text wraps, such as with `Utah residents`.

However, for one-line facet lines, `align=start` causes the facet value text to be a pixel or two higher than it should be. I'd rather have the one-line case look right.