### PR TITLE
After faceted search, rerender in one stage instead of two

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -33,7 +33,7 @@ pyasn1-modules==0.2.2
 pyasn1==0.4.4
 python-dateutil==2.7.5
 pytz==2018.7
-PyYAML==3.13
+PyYAML==4.2b1
 requests==2.21.0
 rsa==4.0
 six==1.11.0

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -34,7 +34,7 @@ pyasn1==0.4.4
 python-dateutil==2.7.5
 pytz==2018.7
 PyYAML==3.13
-requests==2.20.1
+requests==2.21.0
 rsa==4.0
 six==1.11.0
 swagger-spec-validator==2.4.1

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -39,5 +39,5 @@ rsa==4.0
 six==1.11.0
 swagger-spec-validator==2.4.1
 typing==3.6.6
-urllib3==1.22
+urllib3==1.24.1
 Werkzeug==0.14.1

--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -60,7 +60,8 @@ class App extends Component {
       // facetDescription - The description of the facet.
       // esFieldName - The elasticsearch field name of the facet.
       // facetValue
-      searchResults: []
+      searchResults: [],
+      awaitingApi: false
     };
 
     this.apiClient = new ApiClient();
@@ -68,12 +69,14 @@ class App extends Component {
     this.facetsApi = new FacetsApi(this.apiClient);
     this.facetsCallback = function(error, data) {
       if (error) {
+        this.setState({ awaitingApi: false });
         console.error(error);
         // TODO(alanhwang): Redirect to an error page
       } else {
         this.setState({
           facets: this.getFacetMap(data.facets),
-          totalCount: data.count
+          totalCount: data.count,
+          awaitingApi: false
         });
       }
     }.bind(this);
@@ -121,6 +124,10 @@ class App extends Component {
     this.updateFacets = this.updateFacets.bind(this);
     this.handleSearchBoxChange = this.handleSearchBoxChange.bind(this);
     this.loadOptions = this.loadOptions.bind(this);
+  }
+
+  shouldComponentUpdate(nextProps, nextState) {
+    return !nextState.awaitingApi;
   }
 
   render() {
@@ -269,7 +276,10 @@ class App extends Component {
       isSelected
     );
     // Update the state
-    this.setState({ selectedFacetValues: selectedFacetValues });
+    this.setState({
+      selectedFacetValues: selectedFacetValues,
+      awaitingApi: true
+    });
     // Update the facets grid.
     this.facetsApi.facetsGet(
       {

--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -61,7 +61,7 @@ class App extends Component {
       // esFieldName - The elasticsearch field name of the facet.
       // facetValue
       searchResults: [],
-      awaitingApi: false
+      awaitingFacetsApi: false
     };
 
     this.apiClient = new ApiClient();
@@ -69,14 +69,14 @@ class App extends Component {
     this.facetsApi = new FacetsApi(this.apiClient);
     this.facetsCallback = function(error, data) {
       if (error) {
-        this.setState({ awaitingApi: false });
+        this.setState({ awaitingFacetsApi: false });
         console.error(error);
         // TODO(alanhwang): Redirect to an error page
       } else {
         this.setState({
           facets: this.getFacetMap(data.facets),
           totalCount: data.count,
-          awaitingApi: false
+          awaitingFacetsApi: false
         });
       }
     }.bind(this);
@@ -127,7 +127,7 @@ class App extends Component {
   }
 
   shouldComponentUpdate(nextProps, nextState) {
-    return !nextState.awaitingApi;
+    return !nextState.awaitingFacetsApi;
   }
 
   render() {
@@ -278,7 +278,7 @@ class App extends Component {
     // Update the state
     this.setState({
       selectedFacetValues: selectedFacetValues,
-      awaitingApi: true
+      awaitingFacetsApi: true
     });
     // Update the facets grid.
     this.facetsApi.facetsGet(

--- a/ui/src/components/facets/FacetCard.js
+++ b/ui/src/components/facets/FacetCard.js
@@ -79,13 +79,6 @@ class FacetCard extends Component {
     this.isDimmed = this.isDimmed.bind(this);
   }
 
-  componentWillReceiveProps(nextProps) {
-    this.totalFacetValueCount = this.sumFacetValueCounts(
-      nextProps.facet.values,
-      this.props.selectedValues
-    );
-  }
-
   render() {
     const { classes } = this.props;
 
@@ -123,7 +116,10 @@ class FacetCard extends Component {
         <Typography>{this.props.facet.name}</Typography>
         {this.props.facet.name != "Samples Overview" ? (
           <Typography className={classes.totalFacetValueCount}>
-            {this.totalFacetValueCount}
+            {this.sumFacetValueCounts(
+              this.props.facet.values,
+              this.props.selectedValues
+            )}
           </Typography>
         ) : null}
         <Typography className={classes.facetDescription}>
@@ -162,7 +158,6 @@ class FacetCard extends Component {
         }
       });
     }
-
     return count;
   }
 

--- a/ui/src/components/facets/FacetCard.js
+++ b/ui/src/components/facets/FacetCard.js
@@ -70,11 +70,6 @@ class FacetCard extends Component {
 
     this.facetValues = this.props.facet.values;
 
-    this.totalFacetValueCount = this.sumFacetValueCounts(
-      this.props.facet.values,
-      []
-    );
-
     this.onClick = this.onClick.bind(this);
     this.isDimmed = this.isDimmed.bind(this);
   }


### PR DESCRIPTION
Fixes #63 .
Before:
https://screencast.googleplex.com/cast/NTE1MTQ1NjEyMjM3MjA5NnwwZTlhYjk1NS0zZg
After:
https://screencast.googleplex.com/cast/NTA3MDY0NjA0NDI2MjQwMHxhMzk4MzZmMC0zMw
(The previous two screencasts include a 1 second sleep in the api to represent a slower query).

Previously, after doing a faceted search, the app would do two state changes. The first state change happens immediately after clicking, updating the selectedFacetValues. The second state change happens once we get a response from the api, updating the entire facetsMap. If there is a longish delay while waiting for the response, this results in a somewhat jarring ui effect. 

The idea to fixing this:
1) Introduce a new state in App.js called 'awaitingApi'. This is a boolean meant to represent whether or not the app is waiting for a response from the API. 
2) If awaitingApi is true, do not re-render. This is checked in shouldComponentUpdate, which is invoked before rendering when new states are being received.
3) Update FacetCard.js to update the summed facet values on re-render instead of on prop change. This is necessary because previously, the two render steps allowed for a prop change check to happen in between. I also like changing this because componentWillReceiveProps was deprecated earlier this year. 