### PR TITLE
Expand HistogramFacet tooltip/selection area 

### DIFF
--- a/ui/src/components/facets/HistogramFacet.js
+++ b/ui/src/components/facets/HistogramFacet.js
@@ -22,6 +22,7 @@ const baseSpec = {
     },
     x: {},
     y: {},
+    // opacity is needed for creating transparent bars.
     opacity: {
       field: "opaque",
       type: "nominal",
@@ -88,19 +89,14 @@ class FacetHistogram extends Component {
       })
     };
 
-    // Add an additional copy of the with a count equal to the
-    // maximum count in this facet. This data is transparent, but
-    // makes it easier to select/hover tooltip for facets with
-    // very small bars.
-    const maxCount = data.values.reduce(
-      (acc, curr) => (acc > curr.count ? acc : curr.count),
-      0
-    );
+    // Create transparent bar that extends the entire length of the cart. This
+    // makes tooltip/selection easier for facet values that have very low count.
+    const maxFacetValue = Math.max(...data.values.map(v => v.count));
     data.values = data.values.concat(
       data.values.map(v => {
         const invisible = Object.assign({}, v);
         invisible.opaque = false;
-        invisible.count = maxCount;
+        invisible.count = maxFacetValue;
         return invisible;
       })
     );


### PR DESCRIPTION
Precursor PR: https://github.com/DataBiosphere/data-explorer/pull/270

I spent a while investigating alternatives for implementing this functionality. From what I understand about Vega selections, there doesn't seem to be an easy way to expand the clickable area for a facet bar, short of doing manual click location calculations. It's even more difficult for the tooltip since we don't have any control over what event(s) triggers the tooltip, we can only customize it's look and provide the actual `Handler` for customizing the UI.

This solution ended up being quite simple to implement. That being said, it is still a bit 'hacky' so I can post an issue about this on the vega repo if we'd still like to look for other options.