### PR TITLE
Fix bucketing for facets with 0.0, 1.0

### DIFF
--- a/api/data_explorer/util/elasticsearch_util.py
+++ b/api/data_explorer/util/elasticsearch_util.py
@@ -44,7 +44,8 @@ def _get_field_range_and_cardinality(es, field_name):
     for nesting in nestings:
         aggs = aggs.get(nesting)
 
-    return (aggs['max']['value'] - aggs['min']['value'], aggs['cardinality']['value'])
+    return (aggs['max']['value'] - aggs['min']['value'],
+            aggs['cardinality']['value'])
 
 
 def _get_bucket_interval(es, field_name):

--- a/api/data_explorer/util/elasticsearch_util.py
+++ b/api/data_explorer/util/elasticsearch_util.py
@@ -5,6 +5,7 @@ from elasticsearch import helpers
 from elasticsearch_dsl import Search
 from elasticsearch_dsl import HistogramFacet
 from elasticsearch_dsl import TermsFacet
+from elasticsearch_dsl.aggs import Cardinality
 from elasticsearch_dsl.aggs import Max
 from elasticsearch_dsl.aggs import Min
 from elasticsearch_dsl.aggs import Nested
@@ -18,7 +19,7 @@ from filters_facet import FiltersFacet
 from flask import current_app
 
 
-def _get_field_range(es, field_name):
+def _get_field_range_and_cardinality(es, field_name):
     search = Search(using=es, index=current_app.config['INDEX_NAME'])
     # Traverse down the nesting levels from the root field, until we reach the leaf.
     # Need to traverse until the root, because we have to build the search object
@@ -37,21 +38,26 @@ def _get_field_range(es, field_name):
 
     bucket.metric('max', Max(field=field_name))
     bucket.metric('min', Min(field=field_name))
+    bucket.metric('cardinality', Cardinality(field=field_name))
 
     aggs = search.params(size=0).execute().aggregations.to_dict()
     for nesting in nestings:
         aggs = aggs.get(nesting)
 
-    return (aggs['max']['value'] - aggs['min']['value'])
+    return (aggs['max']['value'] - aggs['min']['value'], aggs['cardinality']['value'])
 
 
-def _get_bucket_interval(es, field_name, field_type):
-    field_range = _get_field_range(es, field_name)
-    # If an integer field has 0s and 1s, return 1 instead of .1
-    is_integer_field = field_type in ['long', 'integer', 'short', 'byte']
-    if field_range <= 1 and not is_integer_field:
+def _get_bucket_interval(es, field_name):
+    field_range, cardinality = _get_field_range_and_cardinality(es, field_name)
+    if field_range < 1:
         return .1
-    if field_range < 8:
+    elif field_range == 1 and cardinality > 2:
+        return .1
+    elif field_range == 1 and cardinality == 2:
+        # Some datasets have (0, 1) instead of booleans. Return 1 for that case
+        # instead of .1.
+        return 1
+    elif field_range < 8:
         return 1
     elif field_range < 20:
         return 2
@@ -305,8 +311,7 @@ def get_elasticsearch_facet(es, elasticsearch_field_name, field_type):
         # TODO: When https://github.com/elastic/elasticsearch/issues/31828
         # is fixed, use AutoHistogramFacet instead. Will no longer need 2
         # steps.
-        interval = _get_bucket_interval(es, elasticsearch_field_name,
-                                        field_type)
+        interval = _get_bucket_interval(es, elasticsearch_field_name)
         es_facet = HistogramFacet(
             field=elasticsearch_field_name, interval=interval)
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -48,5 +48,11 @@
   },
   "jest": {
     "preset": "jest-puppeteer"
-  }
+  },
+  "browserslist": [
+    ">0.2%",
+    "not dead",
+    "not ie <= 11",
+    "not op_mini all"
+  ]
 }


### PR DESCRIPTION
Before:
![before](https://user-images.githubusercontent.com/10929390/53045372-4c0e4400-3442-11e9-889f-8af19b8fcc38.png)

After:
![after](https://user-images.githubusercontent.com/10929390/53045376-4fa1cb00-3442-11e9-8a03-700f1317c698.png)

#240 fixed facets with integers (0, 1), but not floats (0.0, 1.0). So try a different approach that works with both floats and integers.