### PR TITLE
[Lou mocks] HistogramFacet part 1

### DIFF
--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -19,7 +19,7 @@ import ExportUrlApi from "api/src/api/ExportUrlApi";
 import FacetsGrid from "components/facets/FacetsGrid";
 import Search from "components/Search";
 import Header from "components/Header";
-import Montserrat from "libs/fonts/Montserrat-Regular.woff";
+import Montserrat from "libs/fonts/Montserrat-Medium.woff2";
 
 const styles = {
   disclaimer: {

--- a/ui/src/components/facets/HistogramFacet.css
+++ b/ui/src/components/facets/HistogramFacet.css
@@ -1,5 +1,12 @@
 /* Vega tooltip is outside root element, so can't style with inline CSS like
    normal. */
 #vg-tooltip-element {
+  background-color: white;
+  border: 1px solid #dfe3e9;
+  box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.17), 0 3px 2px 0 rgba(0, 0, 0, 0.06),
+    0 0 2px 0 rgba(0, 0, 0, 0.06);
+  color: #333f52;
   font-family: Montserrat;
+  font-size: 12px;
+  padding: 16px;
 }

--- a/ui/src/components/facets/HistogramFacet.js
+++ b/ui/src/components/facets/HistogramFacet.js
@@ -5,13 +5,14 @@ import { Handler } from "vega-tooltip";
 
 import "./HistogramFacet.css";
 import * as Style from "libs/style";
+import colors from "libs/colors";
 import FacetHeader from "components/facets/FacetHeader";
 
 const styles = {
   histogramFacet: {
     ...Style.elements.card,
     margin: "0 25px 28px 0",
-    maxHeight: "400px",
+    maxHeight: "500px",
     overflowY: "auto",
     padding: 0
   },
@@ -22,17 +23,26 @@ const styles = {
 
 const baseSpec = {
   $schema: "https://vega.github.io/schema/vega-lite/v3.json",
-  mark: {
-    type: "bar",
-    cursor: "pointer"
+  config: {
+    axis: {
+      labelColor: colors.gray[0],
+      labelFont: "Montserrat",
+      labelFontWeight: 500,
+      labelPadding: 9,
+      ticks: false
+    }
   },
   encoding: {
     color: {
       field: "dimmed",
       type: "nominal",
       scale: {
-        // First color is default bar color. Second color for unselected bars.
-        range: ["#707986", "#cccfd4"]
+        range: [
+          // Default bar color
+          colors.blue[2],
+          // Unselected bar
+          colors.blue[5]
+        ]
       },
       legend: null
     },
@@ -51,22 +61,27 @@ const baseSpec = {
       },
       legend: null
     }
+  },
+  mark: {
+    type: "bar",
+    cursor: "pointer"
+  },
+  padding: {
+    left: 0,
+    top: 17,
+    right: 0,
+    bottom: 16
   }
 };
 
 const facetValueCountAxis = {
+  axis: {
+    labelFontSize: 10
+  },
   field: "count",
   type: "quantitative",
   title: "",
-  stack: null,
-  axis: {
-    labelColor: "#000000de",
-    labelFont: "Montserrat",
-    labelFontSize: 11
-  },
-  scale: {
-    rangeStep: 20
-  }
+  stack: null
 };
 
 function isCategorical(facet) {
@@ -98,14 +113,13 @@ class HistogramFacet extends Component {
       title: null,
       sort: facetValueNames,
       axis: {
-        labelColor: "#000000de",
-        labelFont: "Montserrat",
-        labelFontSize: 11,
+        labelFontSize: 12,
         labelLimit: 120
       },
       scale: {
-        paddingInner: 0.02,
-        rangeStep: 20
+        paddingInner: 0.419,
+        paddingOuter: 0,
+        rangeStep: 31
       }
     };
     // Make bars horizontal, to allow for more space for facet value names for
@@ -149,7 +163,7 @@ class HistogramFacet extends Component {
               <VegaLite
                 spec={spec}
                 data={data}
-                tooltip={new Handler().call}
+                tooltip={new Handler({ theme: "custom" }).call}
                 onNewView={this.onNewView}
               />
             </div>

--- a/ui/src/components/facets/HistogramFacet.js
+++ b/ui/src/components/facets/HistogramFacet.js
@@ -34,9 +34,6 @@ const baseSpec = {
       labelFontWeight: 500,
       labelPadding: 9,
       ticks: false
-    },
-    view: {
-      //      width: 250,
     }
   },
   encoding: {

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -7,7 +7,11 @@ textarea,
 select,
 button {
   font-family: "Montserrat", sans-serif;
+  /*
+Turn off tabular-nums for now, font pre-loading doesn't work with it.
+Melissa will investigate if we can turn back on.
   font-variant-numeric: tabular-nums;
+*/
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   margin: 0;

--- a/ui/tests/e2e/test.js
+++ b/ui/tests/e2e/test.js
@@ -188,7 +188,7 @@ describe("End-to-end", () => {
     facetBar = await getHistogramFacetBar("Super Population", "European");
     const barColor = await page.evaluate(bar => bar.style.fill, facetBar);
     // Vega translates our hex colors to rgb so it must be validated this way.
-    expect(barColor).toBe("rgb(204, 207, 212)");
+    expect(barColor).toBe("rgb(191, 225, 240)");
   });
 
   async function waitForElasticsearchIndex() {


### PR DESCRIPTION
![1](https://user-images.githubusercontent.com/10929390/54633265-0c387d80-4a3d-11e9-971b-0fbd0410ab75.png)

I had to turn off tabular-nums for now. I will see if I can turn it back on in the next PR.

With tabular-nums, text is cut off:
![1](https://user-images.githubusercontent.com/10929390/54634231-03e14200-4a3f-11e9-84aa-f613cc079ae8.png)

Without tabular-nums, text is no longer cut off:
![2](https://user-images.githubusercontent.com/10929390/54634241-09d72300-4a3f-11e9-8b5a-d0a3e315c49a.png)
