### PR TITLE
Rename "Send to Terra" button to "Save in Terra" button

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Run local Data Explorer with the 1000 Genomes dataset:
   create it by running `gcloud auth application-default login`.
 - `docker-compose up --build`
 - Navigate to `localhost:4400`
-- If you want to use the Send to Terra feature, [do this one-time setup](https://github.com/DataBiosphere/data-explorer#one-time-setup-for-send-to-terra-feature).
+- If you want to use the Save in Terra feature, [do this one-time setup](https://github.com/DataBiosphere/data-explorer#one-time-setup-for-save-in-terra-feature).
 
 ## Run local Data Explorer with a custom dataset
 
@@ -40,7 +40,7 @@ Run local Data Explorer with the 1000 Genomes dataset:
     and [here](https://github.com/DataBiosphere/data-explorer/tree/master/dataset_config/template).
     All files except `gcs.json` must be filled out.
 
-- If you want to use the Send to Terra feature, [do this one-time setup](https://github.com/DataBiosphere/data-explorer#one-time-setup-for-send-to-terra-feature).
+- If you want to use the Save in Terra feature, [do this one-time setup](https://github.com/DataBiosphere/data-explorer#one-time-setup-for-save-in-terra-feature).
 - If `~/.config/gcloud/application_default_credentials.json` doesn't exist,
   create it by running `gcloud auth application-default login`.
 - `DATASET_CONFIG_DIR=dataset_config/<my dataset> docker-compose up --build -t 0`
@@ -134,9 +134,9 @@ update the server implementations:
   such as formatting tools.
 - [Set up git secrets.](https://github.com/DataBiosphere/data-explorer/tree/master/hooks)
 
-#### One-time setup for Send to Terra feature
+#### One-time setup for Save in Terra feature
 
-The Send to Terra feature temporarily stores data in a GCS bucket.
+The Save in Terra feature temporarily stores data in a GCS bucket.
 
 - If you haven't already, fill out [deploy.json](https://github.com/DataBiosphere/data-explorer-indexers/blob/master/dataset_config/template/deploy.json)
   for your dataset.
@@ -147,7 +147,7 @@ The Send to Terra feature temporarily stores data in a GCS bucket.
 - Create export bucket. This only needs to be done once per deploy project.
   Run `deploy/create-export-url-bucket.sh DATASET` from the root of the repo,
   where `DATASET` is the name of the directory in `dataset_config`.
-- The Send to Terra feature requires a service account private key. Follow
+- The Save in Terra feature requires a service account private key. Follow
   these instructions to download a key. This needs to be done once per person
   per deploy project. If three people run Data Explorer with the same deploy
   project, then all three need to download a key for the deploy project.

--- a/api/data_explorer/__main__.py
+++ b/api/data_explorer/__main__.py
@@ -243,31 +243,31 @@ def _process_export_url():
         app.app.config['AUTHORIZATION_DOMAIN'] = dataset_config[
             'authorization_domain']
 
-    # Check preconditions for Export to Terra feature. If a precondition fails,
+    # Check preconditions for Save in Terra feature. If a precondition fails,
     # print a warning but allow app to continue. Someone may want to run Data
-    # Explorer UI locally and not use export to Terra feature.
+    # Explorer UI locally and not use Save in Terra feature.
     deploy_config_path = os.path.join(app.app.config['DATASET_CONFIG_DIR'],
                                       'deploy.json')
     if not os.path.isfile(deploy_config_path):
         app.app.logger.warning(
-            'deploy.json not found. Export to Terra feature will not work. '
-            'See https://github.com/DataBiosphere/data-explorer#one-time-setup-for-send-to-terra-feature'
+            'deploy.json not found. Save in Terra feature will not work. '
+            'See https://github.com/DataBiosphere/data-explorer#one-time-setup-for-save-in-terra-feature'
         )
         return
 
     deploy_config = _parse_json_file(deploy_config_path)
     if not 'project_id' in deploy_config:
         app.app.logger.warning(
-            'Project not set in deploy.json. Export to Terra feature will not work. '
-            'See https://github.com/DataBiosphere/data-explorer#one-time-setup-for-send-to-terra-feature'
+            'Project not set in deploy.json. Save in Terra feature will not work. '
+            'See https://github.com/DataBiosphere/data-explorer#one-time-setup-for-save-in-terra-feature'
         )
         return
 
     project_id = deploy_config['project_id']
     if not project_id or project_id == 'PROJECT_ID_TO_DEPLOY_TO':
         app.app.logger.warning(
-            'Project not set in deploy.json. Export to Terra feature will not work. '
-            'See https://github.com/DataBiosphere/data-explorer#one-time-setup-for-send-to-terra-feature'
+            'Project not set in deploy.json. Save in Terra feature will not work. '
+            'See https://github.com/DataBiosphere/data-explorer#one-time-setup-for-save-in-terra-feature'
         )
         return
     else:

--- a/api/data_explorer/controllers/export_url_controller.py
+++ b/api/data_explorer/controllers/export_url_controller.py
@@ -22,7 +22,7 @@ from data_explorer.models.export_url_response import ExportUrlResponse  # noqa: 
 from data_explorer.util import elasticsearch_util
 from data_explorer.util.dataset_faceted_search import DatasetFacetedSearch
 
-# Send to Terra flow
+# Save in Terra flow
 # - User clicks export button on bottom right of Data Explorer
 # - A dialog pops up, asking user to name cohort. User types "African females"
 #   and clicks Export button
@@ -43,16 +43,16 @@ def _check_preconditions():
                                'deploy.json')
     if not os.path.isfile(config_path):
         error_msg = (
-            'deploy.json not found. Send to Terra feature will not work. '
-            'See https://github.com/DataBiosphere/data-explorer#one-time-setup-for-send-to-terra-feature'
+            'deploy.json not found. Save in Terra feature will not work. '
+            'See https://github.com/DataBiosphere/data-explorer#one-time-setup-for-save-in-terra-feature'
         )
         current_app.logger.error(error_msg)
         raise BadRequest(error_msg)
 
     if not current_app.config['DEPLOY_PROJECT_ID']:
         error_msg = (
-            'Project not set in deploy.json. Send to Terra feature will not work. '
-            'See https://github.com/DataBiosphere/data-explorer#one-time-setup-for-send-to-terra-feature'
+            'Project not set in deploy.json. Save in Terra feature will not work. '
+            'See https://github.com/DataBiosphere/data-explorer#one-time-setup-for-save-in-terra-feature'
         )
         current_app.logger.error(error_msg)
         raise BadRequest(error_msg)
@@ -60,8 +60,8 @@ def _check_preconditions():
     if not current_app.config['EXPORT_URL_GCS_BUCKET']:
         error_msg = (
             'Project not set in deploy.json or export URL GCS bucket not '
-            'found. Send to Terra feature will not work. '
-            'See https://github.com/DataBiosphere/data-explorer#one-time-setup-for-send-to-terra-feature'
+            'found. Save in Terra feature will not work. '
+            'See https://github.com/DataBiosphere/data-explorer#one-time-setup-for-save-in-terra-feature'
         )
         current_app.logger.error(error_msg)
         raise BadRequest(error_msg)
@@ -70,8 +70,8 @@ def _check_preconditions():
                                     'private-key.json')
     if not os.path.isfile(private_key_path):
         error_msg = (
-            'Private key not found. Send to Terra feature will not work. '
-            'See https://github.com/DataBiosphere/data-explorer#one-time-setup-for-send-to-terra-feature'
+            'Private key not found. Save in Terra feature will not work. '
+            'See https://github.com/DataBiosphere/data-explorer#one-time-setup-for-save-in-terra-feature'
         )
         current_app.logger.error(error_msg)
         raise BadRequest(error_msg)

--- a/deploy/create-export-url-bucket.sh
+++ b/deploy/create-export-url-bucket.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Creates GCS bucket for the Send to Terra feature.
+# Creates GCS bucket for the Save in Terra feature.
 #
 # See export_url_controller.py for more information.
 #

--- a/deploy/deploy-api.sh
+++ b/deploy/deploy-api.sh
@@ -23,14 +23,14 @@ dataset=$1
 project_id=$(jq --raw-output '.project_id' dataset_config/${dataset}/deploy.json)
 
 if [ ! -f "dataset_config/${dataset}/private-key.json" ]; then
-	echo "Private key not found. Send to Terra feature will not work. "
-	echo "See https://github.com/DataBiosphere/data-explorer#one-time-setup-for-send-to-terra-feature."
+	echo "Private key not found. Save in Terra feature will not work. "
+	echo "See https://github.com/DataBiosphere/data-explorer#one-time-setup-for-save-in-terra-feature."
 	exit 1
 fi
 
 if ! gsutil ls "gs://${project_id}-export" &> /dev/null; then
-	echo "Export bucket not found. Send to Terra feature will not work. "
-	echo "See https://github.com/DataBiosphere/data-explorer#one-time-setup-for-send-to-terra-feature."
+	echo "Export bucket not found. Save in Terra feature will not work. "
+	echo "See https://github.com/DataBiosphere/data-explorer#one-time-setup-for-save-in-terra-feature."
 	exit 1
 fi
 

--- a/ui/src/components/ExportFab.js
+++ b/ui/src/components/ExportFab.js
@@ -129,7 +129,7 @@ class ExportFab extends React.Component {
           https://github.com/mui-org/material-ui/issues/9275#issuecomment-350479467
         */}
         <div className={"mui-fixed " + classes.exportFab}>
-          <Tooltip title="Send to Terra">
+          <Tooltip title="Save in Terra">
             <ExportButton
               className={classes.exportButton}
               onClick={() => this.handleClick()}
@@ -143,7 +143,7 @@ class ExportFab extends React.Component {
             onClose={this.handleClose}
           >
             <DialogTitle className={classes.dialogTitle} disableTypography>
-              Send to Terra
+              Save in Terra
             </DialogTitle>
             <DialogContent>
               <div className={classes.dialogDesc}>

--- a/ui/tests/e2e/test.js
+++ b/ui/tests/e2e/test.js
@@ -422,7 +422,7 @@ describe("End-to-end", () => {
   }
 
   async function exportToSaturn() {
-    await page.click("svg[title='Send to Terra']");
+    await page.click("svg[title='Save in Terra']");
     // Wait for cohort name dialog
     await page.waitForSelector("#name");
 

--- a/util/delete_entities.py
+++ b/util/delete_entities.py
@@ -1,6 +1,6 @@
 """Delete all entities in a workspace.
 
-This is useful when working on the Send to Terra feature.
+This is useful when working on the Save in Terra feature.
 
 To run:
 


### PR DESCRIPTION
Eventually Data Explorer will be embedded in Terra. "Send to Terra" doesn't make sense when you're already in Terra. "Save in Terra" works for both embedded and stand-alone cases.