### PR TITLE
Change facet header hover and reenable test

### DIFF
--- a/ui/src/components/SaveButton.js
+++ b/ui/src/components/SaveButton.js
@@ -1,5 +1,4 @@
 import React from "react";
-import classNames from "classnames";
 import TextField from "@material-ui/core/TextField";
 import Dialog from "@material-ui/core/Dialog";
 import DialogContent from "@material-ui/core/DialogContent";

--- a/ui/src/components/facets/FacetHeader.js
+++ b/ui/src/components/facets/FacetHeader.js
@@ -1,9 +1,18 @@
 import React, { Component } from "react";
+import classNames from "classnames";
 import { withStyles } from "@material-ui/core/styles";
 
 import colors from "libs/colors";
 
 const styles = {
+  extraFacetHeader: {
+    "&:hover $totalFacetValueCount": {
+      display: "none"
+    },
+    "&:hover $closeIcon": {
+      display: "block"
+    }
+  },
   facetDescription: {
     gridColumn: "1/3",
     color: colors.gray[1],
@@ -32,6 +41,7 @@ const styles = {
   },
   closeIcon: {
     color: colors.gray[1],
+    display: "none",
     padding: "7px 0 0 50px"
   }
 };
@@ -43,8 +53,6 @@ class FacetHeader extends Component {
       hoveredOver: false
     };
 
-    this.mouseEnter = this.mouseEnter.bind(this);
-    this.mouseLeave = this.mouseLeave.bind(this);
     this.handleRemoveFacet = this.handleRemoveFacet.bind(this);
   }
 
@@ -53,24 +61,25 @@ class FacetHeader extends Component {
 
     return (
       <div
-        className={classes.facetHeader}
-        onMouseEnter={this.mouseEnter}
-        onMouseLeave={this.mouseLeave}
+        className={
+          this.props.isExtraFacet
+            ? classNames(classes.facetHeader, classes.extraFacetHeader)
+            : classes.facetHeader
+        }
       >
         <div className={classes.facetName}>{this.props.facet.name}</div>
-        {this.props.isExtraFacet && this.state.hoveredOver ? (
+        {this.props.facet.name != "Samples Overview" && (
+          <div className={classes.totalFacetValueCount}>
+            {this.sumFacetValueCounts(
+              this.props.facet.values,
+              this.props.selectedValues
+            )}
+          </div>
+        )}
+        {this.props.isExtraFacet && (
           <div className={classes.closeIcon} onClick={this.handleRemoveFacet}>
             <clr-icon shape="times" style={styles.clearIcon} size="24" />
           </div>
-        ) : (
-          this.props.facet.name != "Samples Overview" && (
-            <div className={classes.totalFacetValueCount}>
-              {this.sumFacetValueCounts(
-                this.props.facet.values,
-                this.props.selectedValues
-              )}
-            </div>
-          )
         )}
         {this.props.facet.description && (
           <div className={classes.facetDescription}>
@@ -83,14 +92,6 @@ class FacetHeader extends Component {
 
   handleRemoveFacet() {
     this.props.handleRemoveFacet(this.props.facet.es_field_name);
-  }
-
-  mouseEnter() {
-    this.setState({ hoveredOver: true });
-  }
-
-  mouseLeave() {
-    this.setState({ hoveredOver: false });
   }
 
   /**

--- a/ui/tests/e2e/test.js
+++ b/ui/tests/e2e/test.js
@@ -105,31 +105,33 @@ describe("End-to-end", () => {
     await waitForFacetsUpdate(3500);
   });
 
-  /*
-Uncomment after https://github.com/GoogleChrome/puppeteer/issues/4336 is fixed
-
   test("Search box - select row with facet value", async () => {
-    // Type "na19686" into search box and select second result
+    // Type "pat" into search box and select second result
     let searchBox = await page.$x(
       "//div[contains(text(), 'Search to add a facet')]"
     );
     await searchBox[0].click();
-    await searchBox[0].type("na19686");
-    let secondResult = await page.waitForXPath("(//span[contains(text(), 'Add')])[2]");
+    await searchBox[0].type("pat");
+    let secondResult = await page.waitForXPath(
+      "(//span[contains(text(), 'Add')])[2]"
+    );
     await secondResult.click();
 
     // Assert Relationship facet was added and value was selected
-    await waitForFacetsUpdate(2);
+    await waitForFacetsUpdate(1);
     await assertFacet("Relationship", "1", "mother", "831");
 
     // Click on 'x' in facet header, make sure filter was removed
-    let header = await page.waitForXPath("//div[contains(@class, 'FacetHeader-facetHeader') and contains(., 'Grandparents')]");
+    let header = await page.waitForXPath(
+      "//div[contains(@class, 'FacetHeader-facetHeader') and contains(., 'Relationship')]"
+    );
     await header.hover();
-    let closeIcon = await page.waitForSelector("div[class^='FacetHeader-closeIcon-']");
+    let closeIcon = await page.waitForSelector(
+      "div[class^='FacetHeader-closeIcon-']"
+    );
     await closeIcon.click();
     await waitForFacetsUpdate(3500);
   });
-*/
 
   test("Data Explorer URL works", async () => {
     // Add Relationship extra facet and select Relationship=mother.


### PR DESCRIPTION
The problem with the test was, immediately after selecting second drop-down result, mouse was already over facet header:

![1](https://user-images.githubusercontent.com/10929390/57000726-bc83c080-6b69-11e9-88ae-7030484db4c9.png)

So `mouseEnter()` didn't trigger.

Instead of `mouseEnter()`, used CSS to implement hover, as recommended [here](https://github.com/GoogleChrome/puppeteer/issues/4336#issuecomment-487221129).

After making this fix, the test failed due to a different hover problem. I ran `npm install` locally and then test passed; I assume because puppeteer was upgraded.