### PR TITLE
Allow all origins for CORS on export bucket

### DIFF
--- a/deploy/create-export-url-bucket.sh
+++ b/deploy/create-export-url-bucket.sh
@@ -32,5 +32,6 @@ gsutil mb -p ${project_id} ${bucket}
 echo "Setting bucket TTL to 1 day"
 gsutil lifecycle set deploy/export-url-bucket-lifecycle.json ${bucket}
 
+# Needed since Terra is fetching from the browser
 echo "Setting up CORS"
 gsutil cors set deploy/export-url-bucket-cors.json ${bucket}

--- a/deploy/export-url-bucket-cors.json
+++ b/deploy/export-url-bucket-cors.json
@@ -1,11 +1,6 @@
 [
-   {
-      "method":[
-         "GET"
-      ],
-      "origin":[
-         "https://app.terra.bio",
-         "https://bvdp-saturn-dev.appspot.com"
-      ]
-   }
+  {
+    "method": ["GET"],
+    "origin": ["*"]
+  }
 ]


### PR DESCRIPTION
Export was failing for firecloud.terra.bio, and various test instances.