### PR TITLE
Fix blank Data Explorer in old versions of Firefox

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -9,6 +9,7 @@
     "@clr/icons": "^0.13.10",
     "@material-ui/core": "^3.9.2",
     "@material-ui/icons": "^2.0.3",
+    "@webcomponents/custom-elements": "^1.2.4",
     "axios": "^0.18.0",
     "classnames": "^2.2.6",
     "data_explorer_service": "file:src/api",

--- a/ui/src/components/Search.js
+++ b/ui/src/components/Search.js
@@ -1,4 +1,6 @@
 import React from "react";
+// custom-elements needed for old versions of Firefox. Must be before @clr.
+import "@webcomponents/custom-elements";
 import "@clr/icons";
 import "@clr/icons/shapes/essential-shapes.min.js";
 import "@clr/icons/clr-icons.css";


### PR DESCRIPTION
Reported by a Terra user. I was able to reproduce problem with Firefox 51. I confirmed this fixes it.

This is this repo's version of https://github.com/DataBiosphere/terra-ui/pull/1491