### PR TITLE
Pin Python3 version to 3.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,9 +20,6 @@ jobs:
           command: |
             cd ui
             npm install
-            # As of 5/1/19, circleci/classic:latest has node 6.1.0. async is
-            # not supported until node 7.6.0.
-            npm install node@8.11.1 -g
       - save_cache:
           key: node-modules-{{ .Branch }}-{{ checksum "ui/package.json" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,16 +5,16 @@ jobs:
     # ports in docker-compose.yml
     # (https://circleci.com/docs/2.0/docker-compose/).
     machine:
-      image: circleci/classic:latest
+      image: cimg/python:3.6-node # Contains python and node
     steps:
       - checkout
       - restore_cache:
           key: node-modules-{{ .Branch }}-{{ checksum "ui/package.json" }}
       - run:
-          name: "Switch to Python v3.5"
+          name: "Switch to Python v3.6"
           command: |
             pyenv versions
-            pyenv global 3.5.2
+            pyenv global 3.6.5
       - run:
           name: npm install
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
           name: "Switch to Python v3.6"
           command: |
             pyenv versions
-            pyenv global 3.6.5
+            pyenv global 3.6.10
       - run:
           name: npm install
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
             pip install --upgrade pip
             pip install tox
             cd api
-            tox -e py35
+            tox -e py36
       - run:
           name: Run docker-compose for 1000 genomes dataset
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,21 +5,24 @@ jobs:
     # ports in docker-compose.yml
     # (https://circleci.com/docs/2.0/docker-compose/).
     machine:
-      image: ubuntu-1604:202004-01
+      image: circleci/classic:latest
     steps:
       - checkout
       - restore_cache:
           key: node-modules-{{ .Branch }}-{{ checksum "ui/package.json" }}
       - run:
-          name: "Switch to Python v3.6"
+          name: "Switch to Python v3.5"
           command: |
             pyenv versions
-            pyenv global 3.6.10
+            pyenv global 3.5.2
       - run:
           name: npm install
           command: |
             cd ui
             npm install
+            # As of 5/1/19, circleci/classic:latest has node 6.1.0. async is
+            # not supported until node 7.6.0.
+            npm install node@8.11.1 -g
       - save_cache:
           key: node-modules-{{ .Branch }}-{{ checksum "ui/package.json" }}
           paths:
@@ -48,7 +51,7 @@ jobs:
             pip install --upgrade pip
             pip install tox
             cd api
-            tox -e py36
+            tox -e py35
       - run:
           name: Run docker-compose for 1000 genomes dataset
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     # ports in docker-compose.yml
     # (https://circleci.com/docs/2.0/docker-compose/).
     machine:
-      image: cimg/python:3.6-node # Contains python and node
+      image: ubuntu-1604:202004-01
     steps:
       - checkout
       - restore_cache:

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,5 +1,5 @@
 # This must be run in project root, to pick up dataset_config/.
-FROM python:3
+FROM python:3.6
 
 WORKDIR /app
 COPY api/requirements.txt /app


### PR DESCRIPTION
python:3 now gets python 3.10 which some of our dependencies aren't ready for. 